### PR TITLE
Improve episode transcription Season 5 Special Kirk Day (5_999.srt)

### DIFF
--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -341,7 +341,7 @@ it- it Kirk's tweet got a one
 
 54
 00:03:10,300 --> 00:03:13,700
--- 13,3 thousand retweets
+-- 13.3 thousand retweets
 [laughs] and a hundred --
 
 55
@@ -427,7 +427,7 @@ I, like -- I don't have a
 68
 00:03:55,122 --> 00:03:56,967
 specific -- I don't remember
-the, like, moment right? Of- of
+the, like, moment, right? Of- of
 
 69
 00:03:56,967 --> 00:03:58,812
@@ -1361,7 +1361,7 @@ Dan: Yeah.
 
 234
 00:12:11,000 --> 00:12:11,500
-Bekah: So, Dan --
+Bekah: -so, Dan --
 
 235
 00:12:11,700 --> 00:12:12,300
@@ -1390,7 +1390,8 @@ Dan: Cuz you never ... say --
 
 237
 00:12:19,500 --> 00:12:20,700
-Bekah: He- he rehired me [laughs].
+Bekah: He- he rehired me
+[laughs].
 
 238
 00:12:20,700 --> 00:12:26,211
@@ -1399,7 +1400,7 @@ you [all laugh]. Well, yeah. It
 
 236
 00:12:26,211 --> 00:12:27,700
-was ro- it was a rough summer.
+was rou- it was a rough summer.
 It was a weird summer.
 
 237
@@ -1438,7 +1439,7 @@ we just kept going with it. And-
 244
 00:12:46,341 --> 00:12:50,000
 and somewhere along the line, I
-pulled Dan in too [chuckles]?
+pulled Dan in too [chuckles].
 
 245
 00:12:50,000 --> 00:12:50,300
@@ -1489,7 +1490,8 @@ Dan: I don't even understand.
 
 253
 00:13:15,626 --> 00:13:17,000
-Bekah: Yeah. I'm not really sure-
+Bekah: Yeah. I'm not really
+sure-
 
 254
 00:13:16,500 --> 00:13:17,700
@@ -1516,7 +1518,7 @@ you -- yeah. No,
 
 256
 00:13:21,807 --> 00:13:25,677
-it's weird. Good, weird. But
+it's weird. Good weird. But
 it's- it's weird, you know?
 
 257
@@ -1552,7 +1554,7 @@ power of truth.
 
 262
 00:13:38,300 --> 00:13:39,700
-Bekah: I was like, yeah. I am
+Bekah: I was like, "Yeah. I am
 totally-
 
 263
@@ -1563,7 +1565,7 @@ of work -- all of our work are-
 264
 00:13:40,000 --> 00:13:42,000
 Bekah: -here for being fired
-eventually [laughs].
+eventually [laughs]."
 
 265
 00:13:41,700 --> 00:13:42,500
@@ -1614,7 +1616,7 @@ whole thing was contractor, you
 269
 00:14:03,506 --> 00:14:06,386
 know? Cuz I'm a contractor
-too, But, yeah. I'd never done
+too. But, yeah. I'd never done
 
 271
 00:14:06,386 --> 00:14:08,576
@@ -1652,7 +1654,7 @@ was- it was- it was fun.
 277
 00:14:28,317 --> 00:14:31,772
 I'm -- I've been missing, you
-know, Bekah. You gotta ... I
+know, Bekah, you gotta ... I
 
 278
 00:14:31,772 --> 00:14:32,000
@@ -1668,8 +1670,8 @@ Dan: I was gonna say-
 
 280
 00:14:33,000 --> 00:14:34,000
-Bekah: And I got a
-new job [laughs].
+Bekah: And I got a new job
+[laughs].
 
 281
 00:14:33,500 --> 00:14:34,300
@@ -1680,6 +1682,7 @@ Dan: -you got a job. Yeah.
 Yeah. So, you know, with, like,
 insurance-
 
+280
 00:14:40,000 --> 00:14:40,300
 Bekah: Yeah.
 
@@ -1699,8 +1702,8 @@ Dan: So, you know --
 
 282
 00:14:46,111 --> 00:14:50,000
-Bekah: Didn't have that for
-awhile [all chuckle]. So, yeah.
+Bekah: Didn't have that for a
+while [all chuckle]. So, yeah.
 
 283
 00:14:50,000 --> 00:14:51,692
@@ -1806,7 +1809,7 @@ probably-
 295
 00:15:37,991 --> 00:15:39,491
 -probably not bad either. But,
-I blame, yeah.
+I blame -- yeah.
 
 296
 00:15:39,491 --> 00:15:40,991
@@ -1833,7 +1836,7 @@ employ you or give you work or
 
 301
 00:15:54,131 --> 00:15:58,000
-money." So, anybody out there
+money." So, anybody out there,
 please let me know [laughs].
 
 302
@@ -1878,7 +1881,7 @@ good.
 
 306
 00:16:22,700 --> 00:16:25,000 
-Bekah: She -- 100% did not say
+Bekah: She 100% did not say
 that.
 
 305
@@ -1953,7 +1956,7 @@ time.
 
 314
 00:16:54,000 --> 00:16:59,966
-Dan:  Hmm, wait. Who's ... Yeah.Somebody's episode, that was a
+Dan:  Hmm, wait. Who's ... yeah.Somebody's episode, that was a
 
 315
 00:16:59,966 --> 00:17:00,500
@@ -2104,7 +2107,7 @@ for sure. We sure have it all
 
 341
 00:17:56,700 --> 00:17:58,346
-recorded. I don't know if,
+recorded. I don't know if --
 
 341
 00:17:58,346 --> 00:18:00,566
@@ -2146,18 +2149,22 @@ script part-
 00:18:15,057 --> 00:18:15,500
 Bekah:  It was like-
 
+349
 00:18:15,300 --> 00:18:16,000
 Dan: I felt that- I felt that --
 
+350
 00:18:15,500 --> 00:18:16,700
 Bekah: -I was so nervous.
 
+351
 00:18:16,700 --> 00:18:18,000
 Dan: Yeah. That was [inaudible].
 
+352
 00:18:17,000 --> 00:18:18,700
-Bekah: Like, it [laughs] It was,
-like,
+Bekah: Like, it [laughs]- it
+was, like,
 
 349
 00:18:18,866 --> 00:18:22,076
@@ -2291,7 +2298,7 @@ tell? We did, like- we did, like
 
 371
 00:19:40,916 --> 00:19:43,061
-[laughs], this is, yeah.
+[laughs], this is -- yeah.
 
 372
 00:19:43,092 --> 00:19:46,872
@@ -2511,6 +2518,7 @@ Dan: Yeah.
 Bekah: But there's, like, my
 worst nightmare talking to a-
 
+408
 00:21:15,700 --> 00:21:16,000
 Dan: Yeah.
 
@@ -2716,6 +2724,7 @@ Dan: Yeah. Yeah.
 00:22:35,000 --> 00:22:36,000
 Bekah: It's like, even earlier-
 
+440
 00:22:36,300 --> 00:22:37,000
 Dan: Pockets is -- are great.
 
@@ -2913,12 +2922,15 @@ once we get another person on
 this call, you and me, we'll be
 in one box. And Kirk will be in
 
+467
 00:24:24,000 --> 00:24:25,000
 another one [laughs].
 
+468
 00:24:25,000 --> 00:24:25,300
 Bekah: Yeah.
 
+469
 00:24:26,000 --> 00:24:27,700
 Dan: Oh, man. It's crazy. It's
 crazy.
@@ -2946,9 +2958,11 @@ can have any Kirk. Nick has
 00:24:40,981 --> 00:24:41,500
 asked. That's a good question.
 
+473
 00:24:41,500 --> 00:24:42,000
 Dan: Ooh.
 
+474
 00:24:42,000 --> 00:24:44,071
 Bekah: So, in our Slack right
 now, most of
@@ -3178,197 +3192,292 @@ July, I'm just telling jokes for
 15 minutes straight because I
 can do whatever I want.
 
----
-
 510
-00:26:39,176 --> 00:26:41,817
-Dan: That's true. You're the
-keynote speaker. So that'll be
+00:26:38,606 --> 00:26:41,817
+Dan: That'll -- that's true.
+You're the keynote speaker. So,
 
 511
-00:26:41,817 --> 00:26:49,076
-your first and only time being a
-key Joseph's to get away. I did
+00:26:41,817 --> 00:26:44,000
+that'll be your first and only
+time being a keynote speaker
 
 512
-00:26:49,076 --> 00:26:55,257
-not fight. I rejected God to
-keep trying to trick
+00:26:44,000 --> 00:26:44,500
+[all laugh].
 
 513
-00:26:55,257 --> 00:26:58,742
-Bekah: me. Can't fire me
-anymore. All right. But if
+00:26:44,500 --> 00:26:47,000
+Bekah: But is it worth it?
 
 514
-00:26:58,742 --> 00:27:02,227
+00:26:47,000 --> 00:26:49,076
+Dan: Oh, Joe said I should fire
+you again -- wait! I did
+
+512
+00:26:49,076 --> 00:26:51,300
+not fire you [Bekah laughs]. I
+reject the promise. I reject it!
+
+513
+00:26:51,300 --> 00:26:55,257
+God, they keep trying to trick
+me!
+
+513
+00:26:55,257 --> 00:27:01,500
+Bekah: Can't fire me anymore
+[laughs]. All right. But if
+
+514
+00:27:01,500 --> 00:27:02,227
 anybody else
 
 515
-00:27:02,227 --> 00:27:03,936
+00:27:02,227 --> 00:27:05,500
 has jokes, please put them in
 the chat and then I will deliver
 
 516
-00:27:03,936 --> 00:27:05,645
-them
+00:27:05,500 --> 00:27:05,700
+them because I'm-
 
 517
-00:27:05,646 --> 00:27:07,567
-because she needs
+00:27:05,700 --> 00:27:06,500
+Dan: You know what?
 
 518
-00:27:07,567 --> 00:27:11,166
-Dan: to deliver them because you
-are the worst joke receiver in
+00:27:06,500 --> 00:27:07,300
+Bekah: -very good at it.
+
+518
+00:27:07,567 --> 00:27:10,000
+Dan: She needs to deliver them
+because you are the worst joke
+
+519
+00:27:10,000 --> 00:27:11,166
+receiver in
 
 519
 00:27:11,166 --> 00:27:13,146
 the world. You know what she
-does. Yeah. You know what you do
+does? Yeah. You know you do,
 
 520
-00:27:13,146 --> 00:27:14,526
-when you, what I ask you, Joe,
-when I like, I have, there's
-
-521
-00:27:14,526 --> 00:27:15,906
-been
+00:27:13,146 --> 00:27:15,700
+when you -- when I asked you
+jo- when I've like, I have --
 
 522
-00:27:15,906 --> 00:27:20,346
-times where I've like pulled out
-some jokes. Oh yeah. Yeah.
+00:27:15,700 --> 00:27:19,000
+there's been times where I've,
+like, pulled out some jokes.
 
 523
-00:27:20,376 --> 00:27:23,406
-Because I know that you
-appreciate them, but she guesses
+00:27:19,000 --> 00:27:20,000
+Bekah: Oh, yeah?
+
+523
+00:27:20,000 --> 00:27:21,500
+Dan: Yeah. Because I know that
+you appreciate them-
 
 524
-00:27:23,406 --> 00:27:25,311
-the answers. She like, she
-didn't say, I don't know what
+00:27:21,500 --> 00:27:21,700
+Bekah: Mm-hmm.
+
+524
+00:27:22,000 --> 00:27:25,311
+Dan: -but she try -- she guesses
+the answers. She like -- she
 
 525
 00:27:25,311 --> 00:27:27,216
-she like
+didn't say, "I don't know.
+What?" She, like,
 
 526
-00:27:27,936 --> 00:27:33,606
-tries to like it's a riddle. No,
+00:27:27,936 --> 00:27:31,000
+tries to, like, it's a riddle.
+[laughs] You are, right? Like --
 
 527
-00:27:34,836 --> 00:27:36,936
-Bekah: no. Oh no. Dan, I don't
+00:27:31,000 --> 00:27:32,000
+Bekah: Isn't that how everybody
+do it?
+
+527
+00:27:31,500 --> 00:27:35,000
+Dan: No! No. No-
+
+528
+00:27:35,000 --> 00:27:35,700
+Bekah: So, something [??]-
+
+529
+00:27:35,700 --> 00:27:36,300
+Dan: -it's not.
+
+530
+00:27:36,300 --> 00:27:38,700
+Bekah: -"Oh no, Dan. I don't
 know. Can you tell me the
 
 528
-00:27:36,936 --> 00:27:39,036
-answer?
+00:27:38,700 --> 00:27:40,000
+answer [laughs]?"
 
 529
-00:27:40,626 --> 00:27:43,461
-Dan: No, that's not. What are
-you doing? You're fired again.
+00:27:40,626 --> 00:27:43,700
+Dan: No, that's not what -- what
+are you doing? You're fired
 
 530
-00:27:43,461 --> 00:27:46,296
-Not
+00:27:43,700 --> 00:27:44,000
+[laughs].
 
 531
-00:27:46,297 --> 00:27:47,436
-again for the first time.
+00:27:44,000 --> 00:27:46,297
+Bekah: [Laughs] Again?
+
+531
+00:27:46,297 --> 00:27:51,000
+Dan: Not again. For the first
+time I have fired you [Bekah
+
+532
+00:27:51,000 --> 00:27:52,000
+laughs]. [Sighs] Man.
 
 532
 00:27:53,557 --> 00:27:56,257
-Bekah: C. Exactly. Thank you,
-Joe. Joe knows. It's not joke.
+Bekah: See? Exactly. Thank you,
+Joe. Joe knows. It's not a joke.
 
 533
 00:27:56,257 --> 00:27:57,366
 It's a challenge. Every joke is
-the.
+the challenge.
 
 534
 00:27:59,297 --> 00:28:02,477
-Dan: That's not a, it's not a
-joke,
+Dan: That's not a -- mm-mm.
+It's not a joke.
 
 535
 00:28:02,656 --> 00:28:05,777
-Bekah: but a joke then is like a
-story that you tell with a
+Bekah: Well, but a joke then is
+like a story that you tell with
 
 536
-00:28:05,777 --> 00:28:07,517
-punchline at the end in
+00:28:05,777 --> 00:28:08,700
+a punchline at the end, in- in
+your sense of a joke is.
 
 537
-00:28:08,846 --> 00:28:20,656
-Dan: your oh, weird Kirk here.
-Okay. Well, according to
+00:28:07,500 --> 00:28:10,000
+Dan: I mean, you're- you're,
+like, stand up here? You're
 
 538
-00:28:20,656 --> 00:28:25,997
-Kirk, one minute left, so we'll
-see, Kirk was not consulted at
+00:28:10,000 --> 00:28:11,000
+[all laugh] --
 
 539
-00:28:25,997 --> 00:28:30,166
-all for any of this. That is
-true. I try not to consult Kirk
+00:28:11,000 --> 00:28:14,000
+Bekah: Yeah. Isn't that what
+everybody aspires to?
 
 540
-00:28:30,797 --> 00:28:32,326
-at a time on things where
+00:28:14,500 --> 00:28:20,656
+Dan: Oh, wait. Kirk here. Okay.
+Well, according to
+
+538
+00:28:20,656 --> 00:28:23,300
+Kirk, one minute left. So, yeah.
+We'll see.
+
+539
+00:28:23,300 --> 00:28:24,500
+Bekah: One minute. T-minus one
+minute.
+
+540
+00:28:24,500 --> 00:28:27,700
+Dan: Oh, Kirk was not consulted
+at all for any of this. That is
+
+539
+00:28:27,700 --> 00:28:32,500
+true. I try not to consult Kirk
+at a time on things where --
 
 541
 00:28:32,656 --> 00:28:33,136
-Bekah: we need
+Bekah: We'd-
 
 542
-00:28:36,767 --> 00:28:38,566
-Dan: right, exactly. Or, you
-know, where he might have time
+00:28:32,700 --> 00:28:33,700
+Dan: He- he- he --
 
 543
-00:28:38,566 --> 00:28:40,365
-to
+00:28:33,500 --> 00:28:34,300
+Bekah: -somebody be reasonable
+[laughs].
+
+542
+00:28:34,300 --> 00:28:39,500
+Dan: Yeah [laughs]. Yeah, right,
+exactly. Or, you know, where he
+
+543
+00:28:39,500 --> 00:28:40,365
+might have time to
 
 544
-00:28:40,366 --> 00:28:44,416
+00:28:40,366 --> 00:28:44,000
 think about whether he wants to
-engage with us. We try to try to
+engage with us. We try to- try
 
 545
-00:28:44,416 --> 00:28:47,862
-pull him in, you know, before he
-has a channel. You know? Yeah,
+00:28:44,000 --> 00:28:47,000
+to pull him in, you know, before
+he has a chance to, you know?
 
 546
-00:28:47,951 --> 00:28:48,221
-Bekah: no,
+00:28:47,300 --> 00:28:48,221
+Bekah: Yeah, no. We --
 
 547
-00:28:48,221 --> 00:28:48,971
-Dan: we avoid my
+00:28:48,221 --> 00:28:50,000
+Dan: Avoid my ridiculousness.
 
 548
-00:28:48,971 --> 00:28:52,842
-Bekah: ridiculousness, Joe. Yes,
-we do need a scoreboard. Maybe
+00:28:50,000 --> 00:28:52,842
+Bekah: Joe, yes. We do need a
+scoreboard. Maybe
 
 549
-00:28:52,842 --> 00:28:58,872
-that will be next month. Monthly
-challenge, 97 and counting.
+00:28:52,842 --> 00:28:54,700
+that will be next month monthly
+challenge --
+
+550
+00:28:53,700 --> 00:28:55,300
+Dan: Alright. So far it counts
+as one.
+
+551
+00:28:56,000 --> 00:28:58,872
+Bekah: 97 and counting.
 
 550
 00:29:01,061 --> 00:29:05,231
-Dan: Oh God. How did I not see
-that coming? Honestly,
+Dan: [Chuckles] Oh, god. How did
+I not see that coming? Honestly.
 
 551
 00:29:05,741 --> 00:29:08,442
@@ -3376,263 +3485,368 @@ Bekah: I don't know. I didn't
 even think about it. And so we
 
 552
-00:29:08,442 --> 00:29:17,321
+00:29:08,442 --> 00:29:10,000
 started talking and you brought
-it up. Yes. A slack channel or a
+it up.
 
 553
-00:29:17,321 --> 00:29:20,352
-slack bot that posts every time
-that Dan fires
+00:29:11,000 --> 00:29:12,000
+Dan: I don't think it was me.
+
+554
+00:29:14,500 --> 00:29:16,000
+Bekah: Yes. A Slack channel-
+
+555
+00:29:16,000 --> 00:29:16,700
+Dan: Yeah, definitely.
+
+553
+00:29:17,000 --> 00:29:20,352
+Bekah: -or a Slack bot that
+posts every time that Dan fires
+
+554
+00:29:20,352 --> 00:29:20,500
+me.
 
 554
 00:29:20,352 --> 00:29:24,001
-Dan: me. How about a select
+Dan: Hmm. How about a select
 button that just announces the
 
 555
 00:29:24,001 --> 00:29:24,571
-Bekah is fire.
+Bekah is fired again?
 
 556
-00:29:25,922 --> 00:29:28,201
-Bekah: Everybody just
-continuously buyers' me over and
+00:29:25,922 --> 00:29:26,200
+Bekah: Everybody-
 
 557
-00:29:28,201 --> 00:29:32,653
-over. It's okay. Just keep
-firing me. It's fine. Just
+00:29:26,200 --> 00:29:29,000
+Dan: That- that- that I'm doubt-
+that I'm doubt-
 
 558
-00:29:32,653 --> 00:29:37,105
-preparing to
+00:29:26,300 --> 00:29:30,500
+Bekah: -just continuously fires
+me over and over [Dan laughs].
+
+557
+00:29:30,500 --> 00:29:32,653
+It's okay. Just keep firing me.
+It's fine.
+
+558
+00:29:33,700 --> 00:29:34,000
+Dan: Hm.
 
 559
-00:29:37,106 --> 00:29:38,861
-be up here. Yeah, he probably,
-sorry, Kirk, we're sorry that
+00:29:35,000 --> 00:29:38,000
+Bekah: Kirk just preparing to be
+up here.
 
-560
-00:29:38,861 --> 00:29:40,616
-you
+559
+00:29:38,000 --> 00:29:38,861
+Yeah, he probably -- sorry,
+Kirk, we're sorry that you
 
 561
-00:29:40,616 --> 00:29:42,446
-have to prepare for us. We were
-trying to send a drone that
+00:29:40,616 --> 00:29:41,500
+have to prepare for us [laughs].
 
 562
-00:29:42,446 --> 00:29:44,276
-would
+00:29:41,500 --> 00:29:42,000
+Kirk: Yeah.
 
 563
-00:29:44,277 --> 00:29:47,067
-just go scoop up Kirk and bring
-him to Cleveland.
+00:29:42,300 --> 00:29:44,277
+Bekah: We were trying to send a
+drone that would
+
+563
+00:29:44,277 --> 00:29:44,700
+just go scoop up Kirk-
+
+564
+00:29:44,700 --> 00:29:46,000
+Dan: Oh, how we gonna do this?
+
+565
+00:29:44,800 --> 00:29:47,067
+Bekah: -and bring him to
+Cleveland.
 
 564
 00:29:47,817 --> 00:29:51,686
-Dan: Well, maybe it's you will
-cut out the echo. I was just
+Dan: Well, maybe Zoom will cut
+out the echo. I was just
 
 565
-00:29:51,686 --> 00:29:56,426
-thinking I have headphones and
-then I was, I don't know how to
+00:29:51,686 --> 00:29:51,500
+thinking-
 
 566
-00:29:56,426 --> 00:29:58,756
-do that. Really. We're just
-going to try it. And I'm going
+00:29:51,500 --> 00:29:51,700
+Bekah: Oh.
 
 567
-00:29:58,756 --> 00:30:01,086
-to count
+00:29:51,700 --> 00:29:56,000
+Dan: -I would have headphones.
+And then I was -- I don't know
+
+566
+00:29:56,000 --> 00:30:01,700
+how to do that, really. We're
+just gonna try it. And I'm gonna
 
 568
-00:30:01,086 --> 00:30:03,456
-on you guys to tell us if
-there's a bad echo, cause I'm
-
-569
-00:30:03,456 --> 00:30:05,826
-just going
+00:30:01,700 --> 00:30:05,300
+count on you guys to tell us
+if there's a bad echo. Cuz I'm
 
 570
-00:30:05,826 --> 00:30:06,876
-to play it over the speakers.
-And because zoom is actually
+00:30:05,300 --> 00:30:07,000
+just gonna play it over the
+speakers. And because Zoom is
 
 571
-00:30:06,876 --> 00:30:07,926
-usually
+00:30:07,000 --> 00:30:07,926
+actually -- usually
 
 572
-00:30:07,926 --> 00:30:11,737
-pretty good at that. Like, I
-mean, if that's all we have to
+00:30:07,926 --> 00:30:09,000
+pretty good at that. Like-
+
+573
+00:30:09,000 --> 00:30:10,500
+Bekah: One headphone in your ear
+and one headphone in my ear.
+
+574
+00:30:10,500 --> 00:30:11,737
+Dan: I mean, if that's all we
+have to
 
 573
 00:30:11,737 --> 00:30:15,247
-do, you know, we can do
-AirPods or something, but like,
+do, I -- you know, we can do
+AirPods or something. But like,
 
 574
 00:30:15,247 --> 00:30:19,507
-that'll be annoying. I have, I'm
-trying to think if there's any
+that'll be annoying. I have --
+I'm trying to think if there's
 
 575
-00:30:19,507 --> 00:30:27,446
-other solution, literally this
-is the first time I've ever. Sat
+00:30:19,507 --> 00:30:25,300
+any other ... solution. But
+literally, this is the first
 
 576
-00:30:27,446 --> 00:30:31,047
-next to somebody and try to be
-beyond,
+00:30:25,300 --> 00:30:28,000
+time I've ever sat next to
+somebody-
 
 577
-00:30:31,166 --> 00:30:35,696
-Bekah: you know, I mean, if I
-have my computer, I can, yeah.
+00:30:28,000 --> 00:30:29,700
+Bekah: Okay. So, I -- here's --
 
 578
-00:30:35,696 --> 00:30:35,997
-And then like
+00:30:28,300 --> 00:30:31,047
+Dan: -and- and try to be on- be
+on, you know, camera.
+
+577
+00:30:31,166 --> 00:30:35,000
+Bekah: I mean, if I have my
+computer, I can-
+
+578
+00:30:35,000 --> 00:30:35,500
+Dan: Yeah.
 
 579
-00:30:35,997 --> 00:30:38,727
-Dan: you could go over the other
-fucking room and do that like,
+00:30:35,500 --> 00:30:36,300
+Bekah: -put on my AirPods and --
+
+579
+00:30:35,700 --> 00:30:38,727
+Dan: I mean, like, you can go on
+the other fucking room and do
 
 580
-00:30:38,936 --> 00:30:42,146
+00:30:38,727 --> 00:30:38,936
+that, like --
+
+580
+00:30:39,000 --> 00:30:42,146
 oh, sorry. I did not mean to
 curse, but she made me have two
 
 581
-00:30:42,146 --> 00:30:44,756
-beers and she, you know, she
-forced me to do it and,
-
-582
-00:30:44,756 --> 00:30:47,366
-which
+00:30:42,146 --> 00:30:47,366
+beers. And she, you know, she
+forced me to do it. And -- which
 
 583
 00:30:47,366 --> 00:30:49,196
 I've been meaning to talk to HR
-about. And they said you're
+about, and they said you're
 
 584
-00:30:49,196 --> 00:30:56,366
-fired. The reason I swerve is
-because like you going out
+00:30:49,196 --> 00:30:52,500
+fired, so ... [all laugh]. I
+would --
 
 585
-00:30:56,366 --> 00:30:58,586
-somewhere else sounds not
-nothing is my
+00:30:52,500 --> 00:30:53,500
+Bekah: Fired again [laughs].
 
 586
-00:30:58,586 --> 00:31:02,636
-Bekah: point. I meant just have
-my computer and log on and I
+00:30:53,500 --> 00:30:55,500
+Dan: The reason I swore was
+because, like,
+
+585
+00:30:55,500 --> 00:30:58,700
+you going out somewhere else
+sounds not fun is my point.
+
+586
+00:30:58,700 --> 00:30:59,300
+Bekah: I meant-
 
 587
-00:31:02,636 --> 00:31:06,116
-would sit here, but just so I
-could put the sound in my ear,
+00:30:59,300 --> 00:31:00,000
+Dan: I would be sad about that.
 
 588
-00:31:06,477 --> 00:31:07,421
+00:30:59,700 --> 00:31:02,636
+Bekah: -just have my
+computer, and log on, and I
+
+587
+00:31:02,636 --> 00:31:04,000
+would sit here-
+
+588
+00:31:03,500 --> 00:31:05,800
+Dan: Hm. I feel like you- I feel
+like you ended up getting a --
+
+589
+00:31:04,000 --> 00:31:06,477
+Bekah: -but just so I
+could put the sound in my ear.
+
+588
+00:31:06,477 --> 00:31:08,000
 Dan: I feel like you'd get a
 delay, plus you'd hear me
 
-589
-00:31:07,421 --> 00:31:08,365
-through
-
 590
-00:31:08,366 --> 00:31:17,007
-there too. And through here too.
-So we're going to try.
+00:31:08,000 --> 00:31:14,000
+through there too. And through
+here too [laughs], you know?
 
 591
-00:31:19,257 --> 00:31:21,477
-Bekah: Do they have like covers
-for your air positive. You're
+00:31:14,000 --> 00:31:15,300
+Bekah: Mm-hmm. Mm-hmm.
 
 592
-00:31:21,477 --> 00:31:22,796
-sharing them for someone else.
-Like, you know how like they
+00:31:15,300 --> 00:31:18,500
+Dan: So, we're gonna try it with
+[inaudible].
+
+591
+00:31:19,257 --> 00:31:21,000
+Bekah: Do they have, like,
+covers for your AirPods that
+
+592
+00:31:21,000 --> 00:31:22,796
+you're sharing them for someone
+else? Like, you know how, like,
 
 593
-00:31:22,796 --> 00:31:24,115
-have
+00:31:22,796 --> 00:31:23,000
+they-
 
 594
-00:31:24,116 --> 00:31:27,987
-like the tongue depressor and
-they cover it or like the ear
+00:31:23,000 --> 00:31:24,000
+Dan: Oh, yeah. We couldn't --
+
+594
+00:31:24,116 --> 00:31:25,000
+Bekah: -have like the tongue
+depressor-
 
 595
-00:31:27,987 --> 00:31:30,176
-thing, they put a little thing.
-Do they have one of those for
+00:31:25,000 --> 00:31:26,500
+Dan: My airp- yeah, yeah.
+
+595
+00:31:25,700 --> 00:31:28,000
+Bekah: -and they cover it? Or
+like the ear thing, they put a
 
 596
-00:31:30,176 --> 00:31:30,747
-your AirPods?
+00:31:28,000 --> 00:31:30,747
+little thing? Do they have one
+of those for your AirPods?
 
 597
-00:31:31,977 --> 00:31:34,647
-Dan: The, that's as soon as
-I thought that that's where like
+00:31:31,977 --> 00:31:35,500
+Dan: The -- oh, yeah. That's --
+as soon as I thought- thought of
 
 598
-00:31:34,647 --> 00:31:37,317
-my
+00:31:35,500 --> 00:31:37,317
+that, that's where, like, my
 
 599
-00:31:37,317 --> 00:31:39,926
-AirPods or like grocery now, I
-wouldn't want to share that with
+00:31:37,317 --> 00:31:39,000
+AirPods are, like, gross right
+now. Like, I wouldn't wanna
 
 600
-00:31:39,926 --> 00:31:41,246
-anybody. So that would be an
-embarrassing thing to do as
+00:31:39,000 --> 00:31:42,000
+share that with anybody. So that
+would be an embarrassing thing
 
 601
-00:31:41,246 --> 00:31:42,566
-well.
+00:31:42,000 --> 00:31:42,566
+to do as well [Bekah laughs].
 
 602
 00:31:43,767 --> 00:31:50,156
 There has to be some sort of
-like, I don't know. I feel like
+like ... I dunno. I feel
 
 603
-00:31:50,156 --> 00:31:51,476
-back in the day they used to
-have a lot of cool things where
+00:31:50,156 --> 00:31:52,000
+like back in the day, they used
+to have a lot of cool things of
 
 604
-00:31:51,476 --> 00:31:52,796
-you'd
+00:31:52,000 --> 00:31:52,796
+where you'd
 
 605
 00:31:52,797 --> 00:31:55,076
-split the, you know, I probably
-honestly, yeah, where they'd
+split the, you know? I probably,
+honestly have --
 
 606
-00:31:55,076 --> 00:31:57,355
-have
+00:31:55,076 --> 00:31:56,700
+Bekah: Did they have lots of
+cool things?
+
+606
+00:31:56,700 --> 00:31:57,355
+Dan: Yeah. Where they'd have
 
 607
 00:31:57,356 --> 00:32:00,057
@@ -3640,182 +3854,324 @@ a little splitter. So you have
 your iPod and the cord with the
 
 608
-00:32:00,057 --> 00:32:04,586
-two things, and then you could
-sit next to your friend in the,
+00:32:00,057 --> 00:32:02,000
+two things, and then you could-
+could sit-
 
 609
-00:32:04,707 --> 00:32:06,911
-or in the bus or the car and
-both of them the same thing.
+00:32:01,000 --> 00:32:02,000
+Bekah: Oh, I didn't have an
+iPod. 
+
+609
+00:32:02,000 --> 00:32:04,707 
+Dan: -in those cars. You could
+sit next to your friend in the
+
+609
+00:32:04,707 --> 00:32:06,700
+-- or in the bus or the car and
+both just do the same thing.
 
 610
-00:32:06,911 --> 00:32:09,115
-Yeah. But
+00:32:06,700 --> 00:32:06,911
+Bekah: What?
+
+610
+00:32:06,911 --> 00:32:08,000
+Dan: Yeah.
 
 611
-00:32:09,116 --> 00:32:13,287
-those were recorded, you know,
-they were like, no, I feel like
+00:32:08,000 --> 00:32:08,700
+Bekah: I said --
+
+611
+00:32:08,700 --> 00:32:11,000
+Dan: But those were recorded,
+you know? they were like --
 
 612
-00:32:13,287 --> 00:32:17,291
-cool. Kids in high school that
-listened to cool music and had
+00:32:11,000 --> 00:32:12,000
+Bekah: Old people?
+
+612
+00:32:12,000 --> 00:32:16,000
+Dan: No. For like cool kids in
+high school that listened to
 
 613
-00:32:17,291 --> 00:32:23,382
-cool friends. I didn't have it
-either. It just seemed cool.
+00:32:16,000 --> 00:32:17,700
+cool music and had cool friends.
 
 614
-00:32:27,281 --> 00:32:30,701
-Bekah: Kirk is talking. It's set
-up there. Where is he? Kirk,
+00:32:17,700 --> 00:32:19,900
+Bekah: I was not a cool kid with
+cool friends in high school
 
 615
-00:32:31,271 --> 00:32:31,362
-are
+00:32:19,900 --> 00:32:20,000
+[laughs].
 
 616
-00:32:31,362 --> 00:32:35,007
-Kirk: you here? I mean, I can
-see you. I want you to know, I
+00:32:20,000 --> 00:32:23,000
+Dan: Alright. I didn't have it
+either, so ... it just seemed
 
 617
-00:32:35,007 --> 00:32:38,652
-just
+00:32:23,000 --> 00:32:23,382
+cool [all laugh].
 
 618
-00:32:38,652 --> 00:32:41,576
-shouted watching the stream
-while I was getting ready. And
+00:32:23,700 --> 00:32:24,300
+Kirk Shillingford: What?
+[Inaudible].
+
+614
+00:32:24,300 --> 00:32:28,300
+Bekah: Can watch the other cool
+kids. Ooh, Kirk is talking. It's
+
+615
+00:32:28,300 --> 00:32:29,000
+said up there.
+
+616
+00:32:29,000 --> 00:32:29,500
+Dan: Oh, oh.
+
+617
+00:32:29,500 --> 00:32:30,000
+Bekah: Where is he?
+
+618
+00:32:30,000 --> 00:32:32,000
+Dan: Kirk, are you here?
+
+616
+00:32:32,000 --> 00:32:33,000
+Kirk:  I mean, I can see you.
+
+617
+00:32:33,000 --> 00:32:34,000
+Dan: Hey! There you are
+[laughs].
+
+618
+00:32:33,500 --> 00:32:34,000
+Bekah: Kirk!!!
 
 619
-00:32:41,576 --> 00:32:44,500
-then
+00:32:35,700 --> 00:32:37,500
+Kirk: I want you to know, like
+--
+
+617
+00:32:37,500 --> 00:32:39,000
+Bekah: [Laughs] I just shouted.
+
+618
+00:32:39,000 --> 00:32:39,700
+Dan: It's Kirk!
+
+618
+00:32:39,700 --> 00:32:43,500
+Kirk: I, like, feel watching the
+stream while I was getting ready.
+
+619
+00:32:43,500 --> 00:32:45,000
+And then,
 
 620
-00:32:45,071 --> 00:32:46,301
-there, wasn't a moment where I'm
-like, this is there's a lot
-
-621
-00:32:46,301 --> 00:32:47,531
-going
+00:32:45,071 --> 00:32:47,531
+there was a moment where I'm
+like, "This is -- there's a lot
 
 622
 00:32:47,531 --> 00:32:51,056
-on here. I don't know where I
-fit in. Don't have any jokes
+of going on here. I don't know-
+I don't know where I fit in.
 
 623
-00:32:51,056 --> 00:32:54,581
-and
+00:32:52,000 --> 00:32:54,581
+I don't have any jokes. And
 
 624
-00:32:54,582 --> 00:33:05,547
-I don't have any jokes, rule
-formats. So, you know, Bekah. I
+00:32:54,582 --> 00:32:59,000
+I don't have, like, any jokes
+[inaudible] rule formats. So --
 
 625
-00:33:05,547 --> 00:33:07,977
+00:32:59,000 --> 00:33:01,000
+Bekah: But you're the best. So
+--
+
+625
+00:33:01,500 --> 00:33:06,500
+Kirk: You know? Bekah, I- I
 feel like, what do you think are
-jokes and not what other people
 
 626
-00:33:16,497 --> 00:33:19,467
-put them together and said, that
-is all of jokes.
+00:33:06,500 --> 00:33:09,000
+jokes and not what other
+[inaudible] [laughs].
 
 627
-00:33:25,017 --> 00:33:27,671
-Dan: I'm so glad you're here.
-Says that was decades ago. I
+00:33:09,500 --> 00:33:10,000
+Bekah: [All laugh] Oh, no!
+
+626
+00:33:11,500 --> 00:33:14,000
+Kirk: I just feel like you've
+taken, like, stand-up and
+
+627
+00:33:14,000 --> 00:33:18,500
+competition, and you, like, flip
+them together instead that is
 
 628
-00:33:27,671 --> 00:33:30,325
-know
+00:33:18,500 --> 00:33:23,500
+all of jokes [all laugh].
+[Inaudible]. There's more than
+
+629
+00:33:23,500 --> 00:33:24,000
+jokes.
+
+627
+00:33:24,000 --> 00:33:26,000
+Dan: Oh, Kirk. I'm so glad
+you're here.
+
+628
+00:33:27,500 --> 00:33:28,000
+Kirk: I just -- 
+
+629
+00:33:28,000 --> 00:33:30,326
+Dan: I think that's -- that was
+decades ago. I know it was
 
 629
 00:33:30,326 --> 00:33:33,626
-it was because it was high
+decades ago because it was high
 school. Thank you for putting
 
 630
-00:33:33,626 --> 00:33:40,017
+00:33:33,626 --> 00:33:35,000
 that out there. I appreciate
-that. All right. Everybody else
+that.
 
 631
-00:33:40,017 --> 00:33:43,916
-has said there's no audio
-issues. We are good.
+00:33:35,000 --> 00:33:36,000
+Kirk: Decades?
 
 632
-00:33:44,277 --> 00:33:48,386
-Bekah: And we got the celebrity
-of the year here. Welcome. It's
+00:33:36,000 --> 00:33:38,500
+Dan: Oh, god.
 
 633
-00:33:48,386 --> 00:33:48,896
-been a great
+00:33:38,500 --> 00:33:39,000
+Bekah: Let's start.
 
 634
-00:33:48,896 --> 00:33:50,396
-Dan: year. The multi-verse
+00:33:39,000 --> 00:33:40,017
+Dan: All right. Everybody else
+
+631
+00:33:40,017 --> 00:33:42,000
+has said there's no audio
+issues.
+
+632
+00:33:42,000 --> 00:33:42,500
+Bekah: Yay!
+
+633
+00:33:43,000 --> 00:33:43,916
+Dan: We are good.
+
+632
+00:33:44,277 --> 00:33:47,000
+Bekah: We did it. We got the
+celebrity of the year here.
+
+633
+00:33:47,000 --> 00:33:48,896
+Welcome. It's been a great year.
+
+634
+00:33:48,500 --> 00:33:51,000
+Dan: The- the celebrity of
+multiverse [chuckles].
 
 635
-00:33:51,547 --> 00:33:53,446
-Kirk: yeah, this entire day,
+00:33:51,500 --> 00:33:51,700
+Bekah: Yeah.
+
+635
+00:33:51,700 --> 00:33:55,346
+Kirk: I did -- this entire day,
 I've just been seeing threats
 
-636
-00:33:53,446 --> 00:33:55,345
-and
-
 637
-00:33:55,346 --> 00:33:57,507
-going. I don't remember talking
-about,
+00:33:55,346 --> 00:33:58,000
+ongoing. I don't remember
+talking though [??]. No.
 
 638
-00:34:00,557 --> 00:34:02,576
-Dan: I've been having the
-opposite problem where I read as
+00:33:58,000 --> 00:34:00,700
+Dan: [Laughs] Yeah. I was --
+I've been having the opposite
+
+639
+00:34:00,700 --> 00:34:02,576
+problem where I r- I read as
 
 639
 00:34:02,576 --> 00:34:05,467
 reading through a thread and was
-like, Oh, who wrote that? Oh,
+like, "Oh, who wrote that? Oh,
 
 640
-00:34:05,467 --> 00:34:05,757
-that was
+00:34:05,467 --> 00:34:06,000
+that was me." Like, it's [all
+laugh] --
 
 641
-00:34:05,757 --> 00:34:08,876
-Bekah: me. Dad said, I think
-we're at lunches.
+00:34:07,000 --> 00:34:08,700
+Bekah: Dan said, "I think we're
+at lunches [laughs]."
 
 642
-00:34:11,126 --> 00:34:15,536
-Kirk: Yes. This is again, I just
-want to make the record clear
+00:34:08,700 --> 00:34:08,876
+[Inaudible].
+
+642
+00:34:11,126 --> 00:34:15,000
+Kirk: It's -- this is ... again,
+I just wanna make the record
 
 643
-00:34:15,536 --> 00:34:21,297
-that I was not consulted about
-any of this mocha I saw, I just
+00:34:15,000 --> 00:34:19,500
+clear that I was not consulted
+about any of this. I woke up,
 
 644
-00:34:21,297 --> 00:34:23,186
-assumed slack. Wasn't working.
+00:34:19,500 --> 00:34:23,186
+I saw, I just assumed Slack
+wasn't working.
+
+646
+00:34:24,000 --> 00:34:25,000
+Dan: [Dan and Bekah laugh] Yeah,
+it does that- it does that --
 
 645
 00:34:24,746 --> 00:34:26,156
-Bekah: Nick Taylor, like
-somebody would maybe read out
+Bekah: Nick Taylor, like,
+somebody would -- maybe read out
 
 646
 00:34:26,156 --> 00:34:27,566
@@ -3823,152 +4179,230 @@ was like,
 
 647
 00:34:28,266 --> 00:34:30,746
-I'm seeing pictures of Kirk and
-Nick is like, it happens
+"I'm seeing pictures of Kirk."
+And Nick is like, "It happens
 
 648
-00:34:30,746 --> 00:34:33,777
-sometimes. And it does like
-sometimes slack put other
+00:34:30,746 --> 00:34:32,000
+sometimes." And it does. Like,
+sometimes-
+
+649
+00:34:32,000 --> 00:34:32,300
+Dan: It does happen.
+
+650
+00:34:32,300 --> 00:34:33,700
+Bekah: -Slack put other-
+
+651
+00:34:32,700 --> 00:34:33,000
+Kirk: Yeah.
 
 649
 00:34:33,777 --> 00:34:34,737
-people's pictures
+Bekah: -people's pictures.
 
 650
-00:34:36,447 --> 00:34:37,976
-Dan: upside down, you know, and
+00:34:35,500 --> 00:34:37,976
+Dan: Not upside down usually
+though.
 
 651
-00:34:38,007 --> 00:34:38,336
-Bekah: flipped it.
+00:34:37,976 --> 00:34:39,700
+Bekah: No. And flipped it
+[inaudible] and reversed it.
 
 652
 00:34:39,896 --> 00:34:42,567
-Kirk: Okay. So I'm going to be
-clear. I was very dense. It took
+Kirk: Okay. So I'm gonna be
+clear. I was very dense. It
 
 653
-00:34:42,567 --> 00:34:46,297
-me way too long to figure out
-that's what that was. Again, I'm
+00:34:42,567 --> 00:34:45,700
+took me way too long to figure
+out that's what that was. Again,
 
 654
-00:34:46,516 --> 00:34:50,567
-probably just not working. And
-then I thought it was like, oh,
+00:34:45,700 --> 00:34:50,000
+I'm just -- I thought Slack was
+not working. And then I thought
+
+656
+00:34:50,000 --> 00:34:50,567
+it was like,
 
 655
 00:34:50,567 --> 00:34:54,597
-okay. Let's add a one way for
-Kirk to distinguish himself and
+"Okay. Let's add one way for
+Kirk to distinguish himself
 
 656
 00:34:54,597 --> 00:34:57,597
-other people. But it wasn't even
-about me, which I feel like is
+from other people." But it
+wasn't even about me, which I
 
 657
-00:34:57,597 --> 00:35:01,436
-Bekah: the perfect
+00:34:57,597 --> 00:34:58,000
+feel like it's the --
+
+657
+00:34:58,000 --> 00:35:01,000
+Bekah: It's all about you. Every
+part of it is.
 
 658
-00:35:01,436 --> 00:35:05,336
-Kirk: days about. That's really
-what, it's a, it's a VC event.
+00:35:01,000 --> 00:35:05,000
+Kirk: Kirk Day is about ...
+everyone. It's a- it's a VC
 
 659
-00:35:05,427 --> 00:35:05,847
-I'm just
+00:35:05,000 --> 00:35:05,847
+event. I'm just-
 
 660
-00:35:07,376 --> 00:35:09,626
-Bekah: celebrating how much we
-love Kurt.
+00:35:06,000 --> 00:35:06,500
+Bekah: It's about-
 
 661
-00:35:12,146 --> 00:35:12,356
-Kirk: We're
+00:35:06,500 --> 00:35:07,000
+Kirk: -just this small --
+
+662
+00:35:07,000 --> 00:35:09,626
+Bekah: -celebrating how much we
+love Kirk.
+
+663
+00:35:09,626 --> 00:35:10,500
+Dan: Yap. It's true.
+
+661
+00:35:10,700 --> 00:35:11,000
+Kirk: No.
 
 662
 00:35:12,356 --> 00:35:14,876
-Bekah: lucky that Missy Elliott
-responded to you. So we can
+Bekah: We're lucky that Missy
+Elliott responded to you. So we
 
 663
 00:35:14,876 --> 00:35:18,507
-remember every day it's like
-Valentine's day because some
+can remember every day -- it's
+like Valentine's day. Because
 
 664
-00:35:18,507 --> 00:35:21,027
-people don't like Valentine's
-day. Cause they're like, what is
+00:35:18,507 --> 00:35:20,500
+some people don't like
+Valentine's day, cuz they're
+
+665
+00:35:20,500 --> 00:35:21,027
+like, "What is
 
 665
 00:35:21,027 --> 00:35:24,657
 this? It's a commercial holiday
-too. So us chocolate and flowers
+to sell us chocolate, and flowers,
 
 666
-00:35:24,717 --> 00:35:29,217
-and cars. And, but it's also a
-day to like remind you to stop
+00:35:24,717 --> 00:35:28,700
+and cars. And -- but it's also a
+day to, like, remind you to stop
 
 667
-00:35:29,217 --> 00:35:33,507
-and think like, oh, I am going
-to, tell this person that I
+00:35:28,700 --> 00:35:33,000
+and think like, "Oh, I'm going
+to tell this person that I
 
 668
-00:35:33,507 --> 00:35:35,862
-love them today. Right? And so
+00:35:33,000 --> 00:35:37,700
+love them today," right? And so,
 like, we often forget to tell
 
-669
-00:35:35,862 --> 00:35:38,217
-you
-
 670
-00:35:38,217 --> 00:35:42,056
-every single day that we love
-you, Kirk. So this is our Kirk
+00:35:37,700 --> 00:35:41,000
+you every single day that we
+love you, Kirk. So this is our
 
 671
-00:35:42,086 --> 00:35:45,836
-Valentine's day slash Missy
-Elliot day. We do
+00:35:41,000 --> 00:35:45,000
+Kirk Valentine's Day slash Missy
+Elliot Day.
 
 672
-00:35:45,836 --> 00:35:49,137
-Kirk: love you. We love you.
-Let's see, I wasn't prepared for
+00:35:45,000 --> 00:35:46,000
+Dan: We do love you, Kirk.
 
 673
-00:35:49,137 --> 00:35:49,706
-this either, but
+00:35:46,000 -->00:35:47,000
+Bekah: We love you.
+
+673
+00:35:47,500 --> 00:35:50,000
+Kirk: Ah, see? I wasn't prepared
+for this either. Go back to
 
 674
-00:35:53,967 --> 00:35:55,586
-Dan: since it's Kirk Day, do you
-want to back.
+00:35:50,000 --> 00:35:52,000
+these jokes [Bekah and Dan
+laugh]. No, I don't wanna any --
 
 675
-00:35:56,786 --> 00:36:05,637
-Kirk: No. I mean, I feel like I
-have to be the one person who
+00:35:52,000 --> 00:35:53,700
+I didn't sign up for any real
+emotions here.
+
+674
+00:35:52,500 --> 00:35:55,586
+Dan: Kirk, Kirk, since it's Kirk
+Day, do you wanna fire Bekah
+
+675
+00:35:55,586 --> 00:35:56,000
+too?
+
+675
+00:35:56,786 --> 00:35:57,000
+Kirk: No.
+
+676
+00:35:58,000 --> 00:35:58,500
+Dan: [Laughs] Alright.
+
+677
+00:35:58,500 --> 00:35:59,000
+Kirk: I mean-
+
+676
+00:35:59,000 --> 00:35:59,500
+Bekah: Thank you.
+
+677
+00:36:00,000 --> 00:36:00,300
+Dan: Alright.
+
+678
+00:36:00,500 --> 00:36:00,700
+Bekah: Thank you.
+
+677
+00:36:01,000 --> 00:36:05,637
+Kirk: -I feel like [inaudible]
+I have to be the one person who
 
 676
 00:36:05,637 --> 00:36:06,416
-doesn't fight.
+doesn't fire you.
 
 677
-00:36:08,246 --> 00:36:08,936
-Dan: Tell me if people
+00:36:06,416 --> 00:36:08,000
+Dan: Alright. I guess it's --
 
 678
-00:36:08,936 --> 00:36:10,646
-Bekah: need to think of me.
+00:36:08,000 --> 00:36:10,700
+Bekah: How many people do you
+think have fired me?
 
 679
 00:36:10,947 --> 00:36:13,677
@@ -3976,336 +4410,488 @@ Kirk: I mean, just based on the
 chat response, people seem to be
 
 680
-00:36:13,677 --> 00:36:17,592
-really into UV as much as like
-on their tier list of events,
+00:36:13,677 --> 00:36:18,700
+really into you being fired.
+Like, as much as like Kirk Day,
 
 681
-00:36:17,592 --> 00:36:21,507
-Kirk
+00:36:18,700 --> 00:36:21,507
+like, on their tier list of
+events, Kirk
 
 682
-00:36:21,507 --> 00:36:25,617
-day, back of being fired. That's
+00:36:21,507 --> 00:36:26,000
+Day, Bekah being fired, that's
 what the people want.
 
 683
-00:36:26,967 --> 00:36:32,126
+00:36:26,967 --> 00:36:29,700
 Bekah: The people want me to be
-fine. I don't even know what to
+fired [Bekah and Dan laugh]?
+
+684
+00:36:30,500 --> 00:36:31,000
+Kirk: I dunno.
+
+685
+00:36:31,000 --> 00:36:32,126
+Bekah: I don't even know what to
 
 684
 00:36:32,126 --> 00:36:35,487
-do. I'm going to have to like,
+do. I'm gonna have to, like,
 think about this very hard on my
 
 685
-00:36:35,487 --> 00:36:39,927
-two and a half hour, drive out.
-Why everybody loves me fired.
+00:36:35,487 --> 00:36:39,700
+two and a half hour drive home.
+Why everybody wants me to be
 
 686
-00:36:40,677 --> 00:36:43,976
+00:36:39,700 --> 00:36:39,927
+fired?
+
+686
+00:36:40,677 --> 00:36:44,000
 Kirk: Well, you seem to be like
-really enthused about it too,
+really enthused about it, to be
 
 687
-00:36:45,356 --> 00:36:47,306
-because you're the one who
-brings it up. Dan, doesn't
+00:36:44,000 --> 00:36:47,500
+honest. Cuz you're the one who
+brings it up. Dan doesn't bring
 
 688
-00:36:47,306 --> 00:36:47,786
-Bekah: bring it up.
+00:36:47,500 --> 00:36:47,700
+it up.
+
+688
+00:36:47,700 --> 00:36:50,367
+Bekah: No. I'm just shaming him.
 
 689
-00:36:50,367 --> 00:36:52,646
+00:36:50,367 --> 00:36:52,000
 Kirk: It's like your origin
-story. It is,
+story.
 
 690
-00:36:53,007 --> 00:36:54,626
-Bekah: it is my origin story.
+00:36:52,000 --> 00:36:54,626
+Bekah: It is- it is my origin
+story [Dan and Bekah chuckle].
 
 691
 00:36:58,407 --> 00:37:01,467
-Kirk: Not the teaching, not the
-women who is it's like it all
+Kirk: Not teaching, not the
+women who code, like, it's
 
 692
-00:37:01,467 --> 00:37:08,967
-started when Dan fire and then a
-passion live inside, less
+00:37:01,467 --> 00:37:06,000
+all started when Dan fired me.
+And then the passion live inside.
 
 693
-00:37:08,967 --> 00:37:10,991
-Bekah: fire. My other origin
-story is not, it's. It's
+00:37:06,500 --> 00:37:07,000
+Bekah: Listen, my --
 
 694
-00:37:10,991 --> 00:37:13,015
-not,
+00:37:07,000 --> 00:37:09,700
+The second time it happened,
+let's fire.
+
+693
+00:37:10,000 --> 00:37:13,000
+Bekah: My other origin story is
+not a -- it's- it's not --
 
 695
-00:37:13,077 --> 00:37:19,916
-it's rated PG 13 decoding.
+00:37:13,077 --> 00:37:15,000
+it's rated PG-13.
 
 696
-00:37:21,117 --> 00:37:26,657
-Kirk: Oh, why did I get into
-coding? I didn't, you
+00:37:16,000 --> 00:37:17,000
+Dan: What?
 
 697
-00:37:26,657 --> 00:37:29,146
-Bekah: can tell that one, but
-then people always feel awkward.
+00:37:18,000 --> 00:37:20,000
+Bekah: Why I got into coding?
+
+696
+00:37:20,700 --> 00:37:26,500
+Kirk: Oh, why did I get into
+coding? I didn't -- I was have
+
+697
+00:37:26,500 --> 00:37:26,657
+to -- 
+
+697
+00:37:26,657 --> 00:37:28,500
+Bekah: I mean, I can tell that
+one, but then people always feel
+
+698
+00:37:28,700 --> 00:37:29,000
+awkward.
 
 698
 00:37:29,146 --> 00:37:32,027
-Cause like when someone asks you
+Cuz, like, when someone asks you
 how you got into coding and you
 
 699
 00:37:32,027 --> 00:37:34,757
 use the word vagina, they're
-suddenly like, oh, weird about
+suddenly like, all weird about
 
 700
-00:37:34,757 --> 00:37:37,427
-it. Yeah, for sure. I don't
+00:37:34,757 --> 00:37:34,800
+it.
+
+701
+00:37:34,800 --> 00:37:37,000
+Dan: Is that what gets you
+PG-13? I don't know [inaudible].
+
+702
+00:37:37,300 --> 00:37:39,700
+Bekah: Yeah, for sure. I don't
 think you can say that in a PG
 
 701
-00:37:37,427 --> 00:37:40,097
-movie,
+00:37:39,700 --> 00:37:40,097
+movie [chuckles].
 
 702
-00:37:43,007 --> 00:37:46,666
-you can drop one. F-bomb in a PG
-13 movie. So we're still a PG 13
+00:37:40,700 --> 00:37:41,300
+Dan: Really?
 
 703
-00:37:46,666 --> 00:37:48,407
-here. We're good, Dan.
+00:37:42,000 --> 00:37:42,300
+Kirk: I --
 
 704
-00:37:50,456 --> 00:37:50,697
-Dan: What's
+00:37:42,300 --> 00:37:42,500
+Dan: I don't know.
+
+702
+00:37:43,007 --> 00:37:46,000
+Bekah: You can drop one f-bomb
+in a PG-13 movie. So we're saw
+
+703
+00:37:46,000 --> 00:37:47,500
+a PG-13 here. We're good.
+
+704
+00:37:47,500 --> 00:37:47,700
+Dan: Boom.
 
 705
-00:37:53,637 --> 00:37:55,166
-Kirk: it because
+00:37:47,700 --> 00:37:48,407
+Bekah: Dan, watch yourself.
+
+704
+00:37:50,456 --> 00:37:52,000
+Dan: What's gonna happen
+[chuckles]?
+
+705
+00:37:52,300 --> 00:37:54,700
+Kirk: So, why would you really
+throw it all to Dan?
 
 706
-00:37:55,166 --> 00:37:58,166
-Bekah: he already dropped one
-today. He thought her one and
+00:37:54,700 --> 00:37:56,000
+Bekah: Because he already
+dropped one-
 
 707
-00:37:58,166 --> 00:38:01,106
-only he was like, I'm going to
-be the one that hit the
+00:37:56,000 --> 00:37:56,500
+Dan: That's true.
 
 708
-00:38:01,106 --> 00:38:02,577
-Dan: truck. Cause I was worried
+00:37:56,500 --> 00:37:57,000
+Bekah: -today.
+
+709
+00:37:57,000 --> 00:37:57,200
+Kirk: Oh.
+
+710
+00:37:57,200 --> 00:37:58,700
+Bekah: He dropped one and only.
+
+711
+00:37:58,700 --> 00:37:59,000
+Dan: Yeah.
+
+707
+00:37:59,000 --> 00:38:01,106
+Bekah: He was like, "I'm gonna
+be the one that gets to drop
+
+708
+00:38:01,106 --> 00:38:01,300
+it."
+
+708
+00:38:01,300 --> 00:38:03,000
+Dan: It's -- cuz I was worried
 about you leaving.
 
 709
-00:38:04,706 --> 00:38:07,016
-Kirk: Okay. Yeah. I know you're
-in Dan's house now. So you get
+00:38:04,706 --> 00:38:06,700
+Kirk: Okay. Yeah. No. You're
+in Dan's house now. So you get,
 
 710
-00:38:07,016 --> 00:38:09,146
-like what's the body
+00:38:06,700 --> 00:38:07,500
+like, what's-
 
 711
-00:38:10,056 --> 00:38:12,451
-Dan: is my office it's office.
-Oh yeah. It's actually a
+00:38:07,500 --> 00:38:08,000
+Dan: It's not my house.
+
+712
+00:38:07,600 --> 00:38:09,000
+Kirk: -where's the body?
+
+711
+00:38:09,000 --> 00:38:11,500
+Dan: It is my office. It's
+office.
+
+712
+00:38:11,500 --> 00:38:11,700
+Kirk: Oh.
+
+713
+00:38:11,700 --> 00:38:12,451
+Bekah: It is an office.
 
 712
 00:38:12,451 --> 00:38:14,846
-Sprockets
+Dan: Yeah. It's actually
+Sprockets'
 
 713
-00:38:14,936 --> 00:38:16,451
+00:38:14,936 --> 00:38:17,966
 office, which is who I do most
 of the work through. But I have
 
-714
-00:38:16,451 --> 00:38:17,966
-my
-
 715
-00:38:17,967 --> 00:38:20,247
-own like, well, I don't know
-this stuff. You know, I have my
-
-716
-00:38:20,247 --> 00:38:22,527
-own
+00:38:17,967 --> 00:38:21,700
+my own, like ... well, I don't
+know this stuff. You know, I
 
 717
-00:38:22,527 --> 00:38:23,817
-room. That is my office.
+00:38:21,700 --> 00:38:23,817
+have my own room that is my
+office in the [inaudible].
 
 718
-00:38:27,577 --> 00:38:28,137
-Kirk: I have like,
+00:38:24,000 --> 00:38:25,500
+Kirk: I interpreted everything-
 
 719
-00:38:29,786 --> 00:38:31,166
-Dan: there's a suite of offices.
+00:38:25,000 --> 00:38:26,700
+Dan: What do you call that words
+of room? What's the word for-
 
 720
-00:38:32,927 --> 00:38:35,987
-Bekah: It's got its own little
-pod. There's a conference in a
+00:38:25,700 --> 00:38:28,500 
+Kirk: -you've said as
+[inaudible] house-
 
 721
-00:38:35,987 --> 00:38:36,916
-couple of offices.
+00:38:26,700 --> 00:38:28,000
+Dan: -that? Like, I have like --
+
+722
+00:38:28,500 --> 00:38:29,000
+Kirk: -in a tree.
+
+719
+00:38:28,700 --> 00:38:31,166
+Dan: There is -- there's a suite
+of offices.
+
+720
+00:38:31,166 --> 00:38:31,300
+Bekah: Yes.
+
+721
+00:38:32,500 --> 00:38:32,927
+Dan: And I have --
+
+720
+00:38:32,927 --> 00:38:33,700
+Bekah: It's got its own little
+pod.
+
+721
+00:38:33,700 --> 00:38:34,300
+Dan: I have one of them.
+
+721
+00:38:34,700 --> 00:38:36,916
+Bekah: There's a conference room
+and a couple of offices.
 
 722
 00:38:37,487 --> 00:38:38,687
 Kirk: I believe that you are
 both in a tree house. I don't
 
-723
-00:38:38,687 --> 00:38:39,887
-believe
-
 724
 00:38:39,887 --> 00:38:41,297
-anything you say. I
+believe anything you say.
 
 725
 00:38:41,297 --> 00:38:42,226
-Bekah: would like to be in a
-tree
+Bekah: I would like to be in a
+tree house.
 
 726
-00:38:42,226 --> 00:38:45,606
-Dan: house. I laid, I went,
-To last week, when was I going?
+00:38:42,226 --> 00:38:47,700
+Dan: That would be cool. Emily
+and I went two weeks -- last
 
 727
-00:38:45,606 --> 00:38:48,986
-I
+00:38:47,700 --> 00:38:48,987
+week -- when was I gone?
 
 728
-00:38:48,987 --> 00:38:52,137
-don't know, two weeks ago,
-whatever it was to Amish country
+00:38:48,987 --> 00:38:50,500
+I dunno. Two weeks ago, whatever
+it was-
 
 729
-00:38:52,137 --> 00:38:54,326
-and got a tree house like
-Airbnb, it's like a newly built
+00:38:50,500 --> 00:38:51,000
+Bekah: Oh, yeah.
+
+730
+00:38:51,500 --> 00:38:53,700
+Dan: -to Amish country and got a
+tree house like Airbnb-
+
+731
+00:38:53,700 --> 00:38:54,326
+Bekah: Oh, nice.
 
 730
 00:38:54,326 --> 00:38:56,515
+Dan: -it's like a newly built
 thing
 
 731
-00:38:56,516 --> 00:38:57,851
-that was like, well, we raised
+00:38:56,516 --> 00:38:59,186
+that was, like, well way raised
 up in the trees and stuff. It
-
-732
-00:38:57,851 --> 00:38:59,186
-was
 
 733
 00:38:59,186 --> 00:39:01,646
-really cool. Yeah. Highly
-recommend
+was really cool. Yeah. Highly
+recommend.
 
 734
-00:39:02,666 --> 00:39:04,181
-Bekah: Gemma. And I drove
-through Amish country recently
-
-735
-00:39:04,181 --> 00:39:05,696
-on
+00:39:02,666 --> 00:39:05,697
+Bekah: Gemma and I drove through
+Amish country recently on
 
 736
-00:39:05,697 --> 00:39:07,661
-accident. Cause I made a wrong
-turn and we went for shopping
-
-737
-00:39:07,661 --> 00:39:09,625
-and
+00:39:05,697 --> 00:39:07,500
+accident cuz I made a wrong
+turn.
 
 738
-00:39:09,626 --> 00:39:12,806
-I, I got some large plastic bins
-for $3, each
+00:39:06,000 --> 00:39:08,500
+Dan: Oh, yeah. That's always-
+that's always a great adventure.
+
+738
+00:39:08,000 --> 00:39:11,000
+Bekah: And we went for shopping.
+And I- I got some large plastic
+
+739
+00:39:11,000 --> 00:39:12,806
+bins for $3 each.
 
 739
 00:39:13,916 --> 00:39:14,967
-Kirk: much plastic things.
+Kirk: Amish plastic bins?
 
 740
-00:39:15,447 --> 00:39:15,896
-Bekah: No
+00:39:15,447 --> 00:39:17,637
+Bekah: No. But there were $3
+[chuckles].
 
 741
 00:39:17,637 --> 00:39:20,097
-Dan: one thing I learned this
+Dan: One thing I learned, this
 trip, lots of Amish people now
 
 742
 00:39:20,126 --> 00:39:23,786
 are into e-bikes, which was a
-surprise to me, but it was cool.
+surprise to me. But it was cool.
 
 743
-00:39:24,266 --> 00:39:27,447
-And it made sense once I thought
-about it. So like lots of,
+00:39:23,786 --> 00:39:25,000
+Bekah: Ooh. I don't think I see
+an e-bike.
+
+743
+00:39:24,266 --> 00:39:26,500
+Dan: And it made sense once I
+thought about it. So, like lots
 
 744
-00:39:27,626 --> 00:39:30,056
-and it was honestly, there was a
-couple of men, mostly a lot of
+00:39:26,500 --> 00:39:29,700
+of -- and it was honestly, there
+was a couple of men, mostly a
 
 745
-00:39:30,056 --> 00:39:32,201
-women riding around on the
-country highways. I mean the
+00:39:29,700 --> 00:39:34,000
+lot of women, riding around on
+the country highways. I mean the
 
 746
-00:39:32,201 --> 00:39:34,346
-same
+00:39:34,000 --> 00:39:34,500
+same highways
 
 747
-00:39:34,347 --> 00:39:37,706
-house as the buggies are riding
-on, but like, but they're just
+00:39:34,500 --> 00:39:37,706
+that the- the buggies are riding
+on, but like -- but they're just
 
 748
 00:39:37,706 --> 00:39:40,376
-like, and they usually had a
-little bike trailer, you know,
+like -- and they usually had a
+little bike trailer, you know?
 
 749
-00:39:40,646 --> 00:39:44,831
-but they're just like fine out.
-I went on. That's
+00:39:40,646 --> 00:39:44,300
+But they're just like flying
+down. I went on an el- on an
 
 750
-00:39:44,831 --> 00:39:46,871
-Kirk: cool, interesting fun
-fact. Early in the history of
+00:39:44,300 --> 00:39:44,831
+electric bike. It's cool.
 
 751
-00:39:46,871 --> 00:39:48,911
-bikes,
+00:39:44,831 --> 00:39:45,300
+Bekah: Mm. Interesting.
+
+752
+00:39:45,300 --> 00:39:45,500
+Dan: Yeah.
+
+750
+00:39:46,000 --> 00:39:48,911
+Kirk: Fun fact. Early in the
+history of bikes,
 
 752
 00:39:49,061 --> 00:39:52,751
@@ -4315,161 +4901,257 @@ upsurge in popularity with women
 753
 00:39:53,112 --> 00:39:55,811
 because it gave them like assets
-to travel and like see their
+to travel and, like, see their
 
 754
-00:39:55,811 --> 00:39:57,611
-friends without having to like
+00:39:55,811 --> 00:39:59,411
+friends without having to, like,
 go through their husbands. And
-
-755
-00:39:57,611 --> 00:39:59,411
-so
 
 756
 00:39:59,411 --> 00:40:02,172
-there was like a big like
-reactionary thing so that people
+so, there was like a big, like,
+reactionary thing so that
 
 757
-00:40:02,351 --> 00:40:05,862
-there like published articles
-about like the bicycle. Is it
+00:40:02,351 --> 00:40:04,000
+people, they were, like,
+published articles about, like,
 
 758
-00:40:05,862 --> 00:40:09,592
-ruining your woman to stay home
-again? Is that how that goes?
+00:40:04,000 --> 00:40:05,862
+the bicycle. Is it
+
+758
+00:40:05,862 --> 00:40:11,700
+ruining your woman [laughs] to
+get them stay home again? Is
 
 759
-00:40:09,592 --> 00:40:13,322
-But
+00:40:11,700 --> 00:40:13,322
+that how that goes?
 
 760
-00:40:13,322 --> 00:40:15,427
-I just, I used to imagine some
-like do just like these
+00:40:13,322 --> 00:40:16,700
+I just- I just imagine some
+like do just like, "Argh! These
 
 761
-00:40:15,427 --> 00:40:17,532
-bicycles,
-
-762
-00:40:17,952 --> 00:40:19,541
-they're hanging out with their
-shreds.
+00:40:16,700 --> 00:40:19,541
+bicycles. They're hanging out
+with their friends!"
 
 763
-00:40:20,621 --> 00:40:23,711
-Bekah: I don't ride a bicycle. I
-don't ride
+00:40:20,621 --> 00:40:21,500
+Bekah: I don't ride a bicycle.
 
 764
-00:40:23,711 --> 00:40:24,342
-Kirk: bicycles.
+00:40:22,000 --> 00:40:22,500
+Dan: What?
 
 765
-00:40:27,251 --> 00:40:28,811
-Dan: Well, both. You don't know
-how to ride a
+00:40:23,000 --> 00:40:24,000
+Bekah: I don't ride bicycles.
+
+766
+00:40:24,700 --> 00:40:26,500
+Kirk: You can't or you don't?
+
+767
+00:40:25,000 --> 00:40:26,000
+Dan: You don't know how?
+
+765
+00:40:27,251 --> 00:40:27,700
+Bekah: Well, both.
+
+766
+00:40:28,000 --> 00:40:28,811
+Dan: You don't know how to ride
+a bike?
 
 766
 00:40:28,811 --> 00:40:31,632
-Bekah: bike? Well, I, I did, but
+Bekah: Well, I- I did. But
 then I fell off it too many
 
 767
-00:40:31,632 --> 00:40:34,751
-times. So I stopped. I don't
-know. I mean, do you know how,
+00:40:31,632 --> 00:40:33,000
+times. So I stopped.
 
 768
-00:40:34,751 --> 00:40:37,870
-if
+00:40:32,500 --> 00:40:33,300
+Dan: [Inaudible].
+
+769
+00:40:33,000 --> 00:40:34,000
+Kirk: So, you did know how to
+ride a bike.
+
+770
+00:40:35,000 --> 00:40:37,870
+Bekah: I don't know. I mean, do
+you know how if
 
 769
 00:40:37,871 --> 00:40:41,396
-you keep falling down. I had a
+you keep falling off? I had a
 bunch of stitches in my elbow.
 
 770
 00:40:41,396 --> 00:40:43,677
-See, there's still scar there. I
+See? There's still scar there. I
 don't think you can see that on
 
 771
-00:40:43,677 --> 00:40:49,077
-screen. Thanks for confirming.
-It was larger. Okay. For a long
+00:40:43,677 --> 00:40:44,000
+screen.
 
 772
-00:40:49,077 --> 00:40:54,356
-time, I once ran into a pole
-while riding on a bicycle.
+00:40:44,000 --> 00:40:44,700
+Dan: I can see it. It's there.
 
 773
-00:40:57,327 --> 00:41:02,097
-Dan: I don't ride bicycle as
-that a flat path. I think, I
+00:40:44,500 --> 00:40:46,000
+Bekah: Thank you. Thanks for
+confirming.
 
 774
-00:41:02,097 --> 00:41:06,867
-feel
+00:40:46,000 --> 00:40:46,700
+Dan: It's very tiny.
 
 775
-00:41:06,867 --> 00:41:08,217
-like, you know how you're just
-not good at it and that's fine.
+00:40:46,700 --> 00:40:50,000
+Bekah: It was larger, okay. For
+a long time [laughs].
 
 776
-00:41:08,217 --> 00:41:09,567
-I
+00:40:50,000 --> 00:40:51,000
+Kirk: Not a contest.
+
+772
+00:40:51,000 --> 00:40:54,356
+Bekah: I once ran into a pole
+while riding on a bicycle
+
+773
+00:40:57,000 --> 00:40:57,700
+[silence]. I don't ride
+bicycles.
+
+774
+00:40:57,700 --> 00:41:01,000
+Kirk: [Inaudible], but the story
+--
+
+775
+00:40:57,800 --> 00:41:00,500
+Dan: [Inaudible].
+
+773
+00:41:02,097 --> 00:41:03,000
+Bekah: I was on a flat path.
+
+774
+00:41:03,000 --> 00:41:03,300
+Dan: Yeah.
+
+775
+00:41:05,000 --> 00:41:05,700
+Kirk: I can relate [inaudible].
+
+774
+00:41:05,500 --> 00:41:07,500
+Dan: I mean, there's like, I
+think -- I feel like you know
+
+775
+00:41:07,500 --> 00:41:10,000
+how. You're just not good at it.
+And that's fine. I mean, like,
 
 777
-00:41:09,567 --> 00:41:12,686
-mean like you you're allowed to
-be not good at things, but you
+00:41:10,000 --> 00:41:12,686
+you -- you're allowed to be not
+good at things, you know? But
 
 778
-00:41:12,686 --> 00:41:15,117
-know how to ride a bike. There's
-my point. You saying I'm not
+00:41:12,686 --> 00:41:14,000
+you know how to ride a bike.
+That's my point.
 
 779
-00:41:15,117 --> 00:41:15,297
-Bekah: good
+00:41:14,300 --> 00:41:16,000
+Bekah: You're saying I'm not
+good at riding bike?
 
 780
-00:41:15,297 --> 00:41:18,867
-Dan: at riding bikes challenge,
-challenge. I just don't
+00:41:16,000 --> 00:41:18,867
+Dan: Yep. Challenge- challenge
+thrown down [chuckles].
 
 781
-00:41:18,867 --> 00:41:21,237
-Kirk: know. How can you swim?
+00:41:18,867 --> 00:41:20,000
+Bekah: I just don't know how
+[chuckles].
+
+781
+00:41:20,000 --> 00:41:21,237
+Kirk: Wait. Can you swim?
 
 782
 00:41:22,166 --> 00:41:23,277
 Bekah: I'm a great swimmer.
 
 783
-00:41:23,907 --> 00:41:26,217
+00:41:23,907 --> 00:41:26,000
 Kirk: Okay. I'm just trying to
-figure out like in a triathlon,
+figure out, like, on -- in a
 
 784
-00:41:26,217 --> 00:41:37,677
-like where are you struggling?
-So it's like swimming, running,
+00:41:26,000 --> 00:41:26,217
+triathlon, like-
 
 785
-00:41:37,677 --> 00:41:38,067
-cycling.
+00:41:26,217 --> 00:41:26,400
+Dan: Whoa.
 
 786
-00:41:39,027 --> 00:41:42,476
-Bekah: Yes. Yeah, that's it.
-I don't know. I probably would
+00:41:26,500 --> 00:41:29,000
+Bekah: I was a lifeguard for
+like 10 years of my life.
+
+787
+00:41:28,000 --> 00:41:30,000
+Dan: She used- she used to,
+like, very well out there, Kirk.
+
+784
+00:41:30,000 --> 00:41:31,700
+Kirk: -where are you struggling?
+
+785
+00:41:32,000 --> 00:41:35,000
+Bekah: I taught children how to
+swim. I taught swim team.
+
+785
+00:41:35,000 --> 00:41:38,067
+Kirk: So it's like swimming,
+running, cycling.
+
+786
+00:41:39,027 --> 00:41:40,500
+Bekah: Mm, yes. Uh-huh. Yeah.
+
+787
+00:41:40,500 --> 00:41:41,000
+Kirk: Fair.
+
+788
+00:41:41,000 --> 00:41:42,476
+Bekah: That's it. I don't know.
+I probably would
 
 787
 00:41:42,476 --> 00:41:45,356
@@ -4478,305 +5160,534 @@ to do that with my child's
 
 788
 00:41:45,356 --> 00:41:47,291
-skateboard and I was like, this
-is going to break my hip. Yeah.
+skateboard, and I was like,
+"This is gonna break my hip."
 
 789
 00:41:47,291 --> 00:41:49,226
-I
+Dan: It's gonna [inaudible].
+Yeah. I
 
 790
-00:41:49,226 --> 00:41:51,071
-was just worried about my no
-sled riding. I once almost broke
+00:41:49,226 --> 00:41:50,000
+was just worried about my
+[inaudible] --
 
 791
-00:41:51,071 --> 00:41:52,916
-my
+00:41:50,000 --> 00:41:52,700
+Bekah: No sled riding. I- I once
+almost broke my
 
 792
-00:41:52,916 --> 00:41:55,527
+00:41:52,700 --> 00:41:55,527
 hip sled riding. I had to go to
 the emergency room. It wasn't
 
 793
-00:41:55,527 --> 00:42:00,806
+00:41:55,527 --> 00:41:58,000
 broken, but gave me lifelong
-problems. I was on a mattress. I
+problems.
 
 794
-00:42:00,806 --> 00:42:03,746
-sled road on a mattress. That
-was a bad idea. So I was like,
+00:41:58,500 --> 00:41:59,000
+Kirk: That's a lot.
 
 795
-00:42:03,746 --> 00:42:06,686
-not
+00:41:58,700 --> 00:42:00,806
+Bekah: When I was- I was on a
+mattress. I
+
+794
+00:42:00,806 --> 00:42:02,500
+sled rode on a mattress. That
+was a bad idea.
+
+795
+00:42:02,500 --> 00:42:04,300
+Dan: So you were sledding, so
+much as mattress riding?
 
 796
-00:42:06,686 --> 00:42:09,686
-good at sled riding. And so then
-these boys in college, they were
+00:42:04,000 --> 00:42:05,000
+Bekah: Well, so --
 
 797
-00:42:09,686 --> 00:42:14,277
-like, Hey, let's take this
-mattress and we'll go on it. And
+00:42:05,000 --> 00:42:05,700
+Dan: That's a little different.
+
+795
+00:42:05,700 --> 00:42:06,686
+Bekah: I was, like, not
+
+796
+00:42:06,686 --> 00:42:08,700
+good at sled riding. And so then
+these boys in college-
+
+797
+00:42:08,700 --> 00:42:09,700
+Kirk: Okay. I'm in a --
+
+797
+00:42:09,000 --> 00:42:12,500
+Bekah: -they were like, "Hey,
+let's take this mattress and
 
 798
-00:42:14,277 --> 00:42:17,487
-you'll land on the mattress and
-it's soft. And that makes sense.
+00:42:12,500 --> 00:42:13,000
+we'll go-
 
 799
-00:42:17,967 --> 00:42:21,686
-Well, okay. So there was a ramp,
-but I was like, don't come over
+00:42:13,000 --> 00:42:13,500
+Kirk: I mean --
+
+798
+00:42:13,500 --> 00:42:16,000
+Bekah: -on it. And you'll land
+on the mattress and it's soft."
+
+799
+00:42:16,000 --> 00:42:16,500
+Dan: Land?
+
+800
+00:42:16,500 --> 00:42:17,700
+Bekah: And that makes sense.
+
+801
+00:42:17,700 --> 00:42:18,500
+Kirk: I'm gonna take pause here.
+
+799
+00:42:17,967 --> 00:42:19,500
+Bekah: Well, okay. So there was
+a ramp-
+
+800
+00:42:19,500 --> 00:42:22,000
+Dan: Yeah! Alright. There's -- I
+knew there's more of the story.
+
+801
+00:42:20,300 --> 00:42:21,686
+Bekah: -but I was like, "Don't
+go over
 
 800
 00:42:21,686 --> 00:42:22,916
-the ring. They promised they
+the ramp. They promised they
 wouldn't go over the ramp and
 
 801
 00:42:22,916 --> 00:42:24,146
-you
+you know what-
 
 802
-00:42:24,146 --> 00:42:26,907
-know what happened? Everybody
+00:42:24,146 --> 00:42:24,300
+Kirk: It does --
+
+803
+00:42:24,200 --> 00:42:26,907
+Bekah: -happened? Everybody
 ditched the mattress except me
 
 803
-00:42:26,907 --> 00:42:30,896
+00:42:26,907 --> 00:42:30,000
 and one other guy. And he landed
-on top of me and he was 200. I
+on top of me and he was 200
 
 804
-00:42:30,896 --> 00:42:33,626
-landed on my head on the sound
-good. I
+00:42:30,000 --> 00:42:32,000
+pounds. I landed on my hip on
+the snow.
 
 805
-00:42:34,226 --> 00:42:38,336
-Kirk: started with, I'm not good
-at sled writing, but as far as
+00:42:31,500 --> 00:42:32,700
+Dan: That is not sound good.
+
+806
+00:42:32,700 --> 00:42:33,700
+Bekah: It was not good.
+
+805
+00:42:33,700 --> 00:42:37,000
+Kirk: Your story started with,
+"I'm not good at sled riding."
+
+806
+00:42:37,000 --> 00:42:38,336
+But as far as
 
 806
 00:42:38,336 --> 00:42:41,456
-I'm aware, now, I remember where
-I live. So I'm admittedly
+I'm aware -- now, remember where
+I live. So, I'm admittedly
 
 807
 00:42:41,456 --> 00:42:45,327
-ignorant of these things, but
-aren't you just, isn't it just
+ignorant of these things. But
+aren't you just -- isn't it
 
 808
 00:42:45,327 --> 00:42:47,277
-like it's happening to you.
+just like physics happening to
+you?
 
 809
-00:42:48,027 --> 00:42:50,597
-Dan: It's mostly the ramp. That
+00:42:47,277 --> 00:42:47,400
+Dan: Yeah.
+
+810
+00:42:47,500 --> 00:42:48,300
+Kirk: Like, how [inaudible] --
+
+809
+00:42:48,027 --> 00:42:50,300
+Dan: It's mostly the ramp that
 was a problem. I feel like
 
 810
-00:42:51,536 --> 00:42:54,746
-Bekah: it's easiest thing.
-You're totally
+00:42:50,300 --> 00:42:50,597
+for --
 
 811
-00:42:54,746 --> 00:42:58,047
-Dan: right though. You just like
-sit on the sled and then let us
+00:42:50,500 --> 00:42:50,700
+Bekah: Well-
 
 812
-00:42:59,097 --> 00:43:00,536
-Bekah: know sometimes like you
-reckon,
+00:42:51,000 --> 00:42:51,500
+Dan: The slide riding-
 
 813
-00:43:01,347 --> 00:43:06,356
-Dan: I like the part about sled
+00:42:51,300 --> 00:42:54,000
+Bekah: -that was- that was my
+second slide riding accident.
+
+814
+00:42:51,500 --> 00:42:54,000
+Dan: -is easiest thing. You just
+put [inaudible]. Alright, Kirk.
+
+811
+00:42:54,000 --> 00:42:56,800
+You totally right though. You
+just like sit on the sled and
+
+812
+00:42:56,800 --> 00:42:57,000
+then-
+
+813
+00:42:57,000 --> 00:42:58,000
+Kirk: Let the [inaudible], you
+know?
+
+814
+00:42:57,300 --> 00:42:59,000
+Dan: -let go out the hill. Yeah.
+
+812
+00:42:59,097 --> 00:43:59,700
+Bekah: No! Sometimes, like, you
+wreck into things on sleds-
+
+813
+00:43:59,700 --> 00:43:01,700
+Dan: So, I feel like the-
+
+814
+00:43:02,000 --> 00:43:02,500
+Bekah: -and bikes.
+
+815
+00:43:02,100 --> 00:43:05,000
+Dan: -important part about sled
 riding is picking your spot.
 
 814
 00:43:06,387 --> 00:43:09,356
-Cause if you go where there's
+Cuz if you go where there's
 like huge ramps or like, I don't
 
 815
-00:43:09,356 --> 00:43:12,447
+00:43:09,356 --> 00:43:11,500
 know where else you crashed, but
-like trees and stuff. Probably
+like trees and stuff, you know-
 
 816
-00:43:12,447 --> 00:43:16,137
-not what slides are hard to
-steal. Like they don't, they
+00:43:11,500 --> 00:43:12,500
+Bekah: Trees. It was a tree.
 
 817
-00:43:16,137 --> 00:43:19,586
-don't, they don't, they're not
-going to like do a sharp turn
+00:43:12,000 --> 00:43:12,700
+Dan: -probably not a good idea.
 
 818
-00:43:19,586 --> 00:43:19,976
-steer.
+00:43:12,700 --> 00:43:13,700
+Bekah: I hit a tree a couple of
+times [chuckles].
+
+816
+00:43:13,700 --> 00:43:15,700
+Dan: Yeah, yeah. Well, slides
+are hard to sti- like, they
+
+817
+00:43:15,700 --> 00:43:16,137
+don't-
+
+818
+00:43:16,137 --> 00:43:16,300
+Bekah: Yeah.
 
 819
-00:43:20,217 --> 00:43:22,766
+00:43:16,300 --> 00:43:18,300
+Dan: -they don't s- they don't
+-- they're not gonna, like, do
+
+818
+00:43:18,300 --> 00:43:20,000
+a sharp turn steer, you know?
+
+819
+00:43:20,217 --> 00:43:22,500
 Bekah: I remastered my fear
-though. My brother is down the
+though. My brother moved-
 
 820
-00:43:22,766 --> 00:43:27,206
-street and has a great sled
-riding. I have gone down that
+00:43:22,500 --> 00:43:22,800
+Dan: Sled is fun.
+
+820
+00:43:22,600 --> 00:43:25,000
+Bekah: -down the street and has
+a great sled riding hill. And I
 
 821
-00:43:27,206 --> 00:43:27,867
-hill multiple times.
+00:43:25,000 --> 00:43:27,867
+have gone down that hill
+multiple times.
 
 822
-00:43:28,047 --> 00:43:30,491
-Dan: You see them, you can
-affect like, like slow gradual
+00:43:28,047 --> 00:43:31,000
+Dan: Yeah. You- you see? You can
+affect like s- like slow gradual
 
 823
-00:43:30,491 --> 00:43:32,935
+00:43:31,000 --> 00:43:32,935
 turns on
 
 824
-00:43:32,936 --> 00:43:37,137
+00:43:32,936 --> 00:43:34,300
 sleds. You know what I mean? But
-like what I'm saying, you can
+like --
 
 825
-00:43:37,137 --> 00:43:38,877
-turn slowly while you're going
-fast, straight down, but you
+00:43:33,500 --> 00:43:35,000
+Bekah: I just [inaudible]
+straight down.
 
 826
-00:43:38,877 --> 00:43:40,617
-have
+00:43:35,500 --> 00:43:36,700
+Dan: What -- I mean, I'm saying,
+you can
+
+825
+00:43:36,700 --> 00:43:38,300
+turn slowly while-
+
+826
+00:43:38,300 --> 00:43:38,500
+Bekah: Yeah.
 
 827
-00:43:40,617 --> 00:43:42,431
-to plan ahead. You have to plan
-ahead or just ditch. It is what
+00:43:38,500 --> 00:43:39,700
+Dan: you're going
+fast, straight down.
 
 828
-00:43:42,431 --> 00:43:44,245
-I
+00:43:40,000 --> 00:43:41,500
+Bekah: I was [inaudible] in the
+ground.
+
+826
+00:43:40,500 --> 00:43:41,000
+Dan: But you have to plan it
+ahead [laughs].
+
+827
+00:43:41,000 --> 00:43:43,700
+You have to plan it ahead or
+just ditch it, is what
 
 829
-00:43:44,456 --> 00:43:45,237
-would, I do want to control.
+00:43:43,700 --> 00:43:45,237
+I would -- what I do when I
+wanna control.
 
 830
-00:43:47,067 --> 00:43:49,137
-Bekah: He says I lift heavy
-things and I flip them down.
+00:43:44,500 --> 00:43:45,300
+Bekah: Not gonna say [??].
+
+831
+00:43:45,500 --> 00:43:45,700
+Dan: Yeah.
+
+832
+00:43:45,700 --> 00:43:46,500
+Kirk: Now in the chat --
+
+833
+00:43:45,800 --> 00:43:48,500
+Bekah: Jeff is correct. He says
+I lift heavy things and I put
+
+834
+00:43:48,500 --> 00:43:49,000
+them down.
 
 831
 00:43:49,137 --> 00:43:50,242
-Dan: Somebody said, we should do
-a challenge, a bike ride shot.
+Dan: Yeah. Somebody said we
+should do a challenge, a bike
 
 832
-00:43:50,242 --> 00:43:51,347
-It
+00:43:50,242 --> 00:43:52,500
+ride challenge. But it [Bekah
+laughs] would be [inaudible]
 
 833
-00:43:51,356 --> 00:43:56,126
-would be it. I can actually sit
-on a bike and not move and not
+00:43:52,500 --> 00:43:53,000
+I can actually-
 
 834
-00:43:56,126 --> 00:43:56,577
-fall over.
+00:43:53,000 --> 00:43:53,700
+Kirk: Well, [inaudible] --
 
 835
-00:43:56,907 --> 00:44:00,086
-Bekah: Deanna has a nickname for
+00:43:53,700 --> 00:43:57,000
+Dan: -I can sit- sit on a bike,
+and not move, and not fall over.
+
+835
+00:43:57,000 --> 00:44:00,086
+Bekah: Dan has a nickname for
 his bike riding.
 
 836
-00:44:01,617 --> 00:44:08,067
-Dan: Yeah. It's all shot. Yeah,
-somebody named, I got it
+00:44:00,700 --> 00:44:01,000
+Dan: Yeah.
 
 837
-00:44:08,246 --> 00:44:10,586
-originally from bike riding,
-but, that was, I don't know
+00:44:01,500 --> 00:44:02,000
+Bekah: Yeah [Bekah and Dan
+chuckle].
+
+836
+00:44:01,617 --> 00:44:05,500
+Dan: Yeah. It's Hotshot. Yeah,
+somebody named -- I got-
+
+837
+00:44:05,500 --> 00:44:07,000
+Kirk: [Inaudible].
+
+837
+00:44:05,700 --> 00:44:09,000
+Dan: -a nickname in- in high
+school. It- it originally from
 
 838
-00:44:10,586 --> 00:44:12,926
-what
+00:44:09,000 --> 00:44:12,926
+bike riding, but ... that was
+[Bekah and Dan chuckle] I don't
 
 839
-00:44:12,927 --> 00:44:18,567
-all that stuff was with. Yeah.
-Like beg his daughters, sent
+00:44:12,927 --> 00:44:13,500
+know what all that stuff was,
+but --
 
 840
-00:44:18,567 --> 00:44:23,202
-me a poop emoji drawings because
-every time they come on, Thing.
+00:44:13,500 --> 00:44:14,500
+Bekah: Oh. Poop emojis?
 
 841
-00:44:23,291 --> 00:44:25,902
-And they always want, you know,
+00:44:14,700 --> 00:44:18,700
+Dan: Oh, nice. Yeah. Bekah's-
+Bekah's daughters sent me a poop
+
+840
+00:44:18,700 --> 00:44:23,291
+emoji drawings because every
+time they come on the thing, and
+
+841
+00:44:23,291 --> 00:44:25,500
+they always want, you know,
 whatever they're waving and
 
 842
-00:44:25,902 --> 00:44:27,581
+00:44:25,500 --> 00:44:27,581
 stuff. And so I just started
-sending people from what he's
+sending poop emojis and they
 
 843
 00:44:27,581 --> 00:44:29,021
-named fight or flights. Well,
+thought of flying. So --
 
 844
-00:44:29,021 --> 00:44:32,722
-Kirk: I've always, that's been
-very validating to me. Bekah's
+00:44:29,021 --> 00:44:31,000
+Kirk: Well, I've always --
+that's been very validating to
 
 845
-00:44:32,742 --> 00:44:34,707
-family associates being with
-like pancakes and hot sauce and
+00:44:31,000 --> 00:44:34,000
+me with, like, Bekah's family
+associates me with, like,
 
 846
-00:44:34,707 --> 00:44:36,672
-like
+00:44:34,000 --> 00:44:38,000
+pancakes and hot sauce. And,
+like, Dan gets poop emojis
 
 847
-00:44:36,702 --> 00:44:37,362
-van kits.
+00:44:38,000 --> 00:44:39,000
+[chuckles].
 
 848
-00:44:39,282 --> 00:44:40,947
-Bekah: So I don't think anybody
-knows this story. So one
+00:44:39,500 --> 00:44:40,000
+Bekah: So I'd-
 
 849
-00:44:40,947 --> 00:44:42,612
-morning,
+00:44:39,700 --> 00:44:40,300
+Dan: [Inaudible].
+
+850
+00:44:40,300 --> 00:44:41,000
+Bekah: -I don't think anybody
+knows this story.
+
+851
+00:44:41,000 --> 00:44:41,700
+Dan: I'm alright with that.
+
+849
+00:44:41,700 --> 00:44:42,612
+Bekah: The one morning,
 
 850
 00:44:42,641 --> 00:44:46,271
-a couple of weeks ago we were
+a couple of weeks ago, we were
 making pancakes and my daughters
 
 851
-00:44:46,271 --> 00:44:50,561
-decided they were going to make
-pan Kirk's some pancakes that
+00:44:46,271 --> 00:44:49,700
+decided they were gonna make
+pan-Kirks [chuckles], some
+
+852
+00:44:49,700 --> 00:44:50,561
+pancakes that
 
 852
 00:44:50,561 --> 00:44:54,101
@@ -4785,46 +5696,64 @@ they argued over who would eat
 
 853
 00:44:54,101 --> 00:44:57,072
-the pan Kirk, but then it, we
-only had a little bit of battery
+the pan-Kirk. But then, it -- we
+only had a little bit of butter
 
 854
-00:44:57,072 --> 00:45:00,641
-life. So there was only one pan
-Kirk and it looked like a tiny
+00:44:57,072 --> 00:45:00,300
+left. So there was only one
+pan-Kirk and it looked like a
 
 855
-00:45:00,641 --> 00:45:05,621
-baby. So I think Gemma, a baby
-Kirk, Kirk is like, that is
+00:45:00,300 --> 00:45:04,700
+tiny baby. So, I think Gemma ate
+baby pan-Kirk [laughs]. Kirk is
 
 856
-00:45:06,222 --> 00:45:08,202
-strange. And
+00:45:04,700 --> 00:45:08,202
+like this strange [laughs] --
 
 857
-00:45:08,202 --> 00:45:11,742
-Kirk: she sent me this like,
-look, they made like, there's
+00:45:08,202 --> 00:45:10,000
+Kirk: She sent me this, like,
+"Look! They made, like,
 
 858
-00:45:11,742 --> 00:45:18,851
-nothing special about the
-pancakes, small pancake. There's
+00:45:10,000 --> 00:45:13,700
+pan-Kirks." There's nothing
+special about the pancakes
 
 859
-00:45:18,851 --> 00:45:22,481
-no like chocolate chip face is
-just a pancake.
+00:45:13,700 --> 00:45:17,000
+itself [Bekah laughs]. It's just
+a small pancake. There's no
+
+859
+00:45:17,000 --> 00:45:20,700
+distinguishing. There's no,
+like, chocolate chip face.
+
+860
+00:45:21,000 --> 00:45:22,700
+It's just a pancake.
 
 860
 00:45:22,811 --> 00:45:24,702
 Bekah: We did our best with what
-we had. Okay.
+we had, okay [laughs]?
 
 861
-00:45:28,302 --> 00:45:33,222
-Kirk: Don't tell them it's very
+00:45:26,000 --> 00:45:27,000
+Dan: Oh, man.
+
+861
+00:45:28,302 --> 00:45:30,000
+Kirk: Well, your best is bad.
+Don't tell them. I was very
+
+862
+00:45:30,000 --> 00:45:33,222
+[chuckles] -- it's very
 heartwarming, but also quite
 
 862
@@ -4834,8 +5763,8 @@ make pancakes from scratch, not
 
 863
 00:45:36,492 --> 00:45:39,851
-the mix. And we're like
-proportions. I learned it at, or
+the mix. And the, like,
+proportions I learned it at are
 
 864
 00:45:39,851 --> 00:45:42,641
@@ -4843,54 +5772,78 @@ the only way I can do it. So I
 can only make like enough
 
 865
-00:45:42,641 --> 00:45:45,506
-pancakes, like a full family,
-but my family quickly, like you
+00:45:42,641 --> 00:45:46,500
+pancakes, like, a full family.
+But my family quickly-
 
 866
-00:45:45,506 --> 00:45:48,371
-don't
+00:45:46,500 --> 00:45:47,000
+Dan: [Inaudible].
+
+866
+00:45:46,600 --> 00:45:49,700
+Kirk: -like, [inaudible] they
+don't want pancakes. So I would
 
 867
-00:45:48,371 --> 00:45:52,572
-want pancakes. So I would just
-eat like two pounds of pancakes
-
-868
-00:45:52,572 --> 00:45:53,021
-myself.
+00:45:49,700 --> 00:45:53,052
+just eat, like, two pounds of
+pancakes myself. Cuz I know --
 
 869
-00:45:53,052 --> 00:45:53,561
-Bekah: Cause I know.
+00:45:53,052 --> 00:45:54,000
+Bekah: You can freeze them- 
 
 870
-00:45:56,862 --> 00:45:58,032
-Dan: It's true. They're good.
-That way.
+00:45:54,000 --> 00:45:55,000
+Dan: Yeah. You- you --
 
 871
-00:45:58,961 --> 00:46:01,211
-Kirk: Or I could eat two pounds,
-right.
+00:45:55,000 --> 00:45:56,000
+Bekah: -and then pop them in the
+toaster.
+
+870
+00:45:56,300 --> 00:45:58,032
+Dan: Yep. It's true. They're
+good that way.
+
+871
+00:45:58,961 --> 00:46:00,700
+Kirk: Or I could eat two pounds
+of pancakes.
 
 872
-00:46:01,211 --> 00:46:04,572
-Dan: So yeah, bragging at this
-point is you get to eat two
+00:46:00,700 --> 00:46:01,211
+Dan: Right.
 
 873
-00:46:04,572 --> 00:46:04,931
-pounds of,
+00:46:01,211 --> 00:46:03,000
+Bekah: Yeah. That's [inaudible]
+[laughs].
+
+874
+00:46:01,300 --> 00:46:02,700
+Dan: So you're not [inaudible]
+you're just bragging at this
+
+873
+00:46:02,700 --> 00:46:05,442
+point, is you get to eat two
+pounds of pancakes.
 
 874
 00:46:05,442 --> 00:46:08,202
-Kirk: and then I go up to them
-like you made them do this.
+Kirk: And then I go up to them
+like, "You made me do this."
+
+875
+00:46:08,202 --> 00:46:11,700
+[Dan laughs] That's the spirit.
 
 875
 00:46:11,981 --> 00:46:16,331
-Dan: I, so we were talking,
+Dan: I -- so we were talking --
 I mean, we wanted to hang out in
 
 876
@@ -4900,7 +5853,7 @@ hang out with people. We talked
 
 877
 00:46:18,552 --> 00:46:21,311
-about doing a podcast, like
+about doing a podcast. Like,
 making this like a live podcast
 
 878
@@ -4909,253 +5862,405 @@ episode. I realized that we
 didn't do a random question or
 
 879
-00:46:26,442 --> 00:46:30,072
-anything like that. So I was
-just, I don't have a plan for
+00:46:26,442 --> 00:46:28,500
+anything like that. So I was-
 
 880
-00:46:30,072 --> 00:46:31,556
-this. I was thinking about
-somebody has a as, as a good,
+00:46:28,500 --. 00:46:28,700
+Kirk: Wait --
 
 881
-00:46:31,556 --> 00:46:33,040
-you
+00:46:29,000 --> 00:46:30,072
+Dan: -just -- I don't have a
+plan for
+
+880
+00:46:30,072 --> 00:46:32,000
+this. I was thinking if I had
+[chuckles] somebody has a --
+
+881
+00:46:32,000 --> 00:46:33,040
+has- has a good, you
 
 882
 00:46:33,041 --> 00:46:35,862
-know, random question or Kirk,
-if you, while in
+know, random question -- or
+Kirk, if you --
 
 883
-00:46:35,862 --> 00:46:39,536
-Kirk: VC, today or riddle really
-icebreaker was which part of
+00:46:35,862 --> 00:46:36,500
+Kirk: Well, in VC today-
 
 884
-00:46:39,536 --> 00:46:43,210
-not,
+00:46:36,500 --> 00:46:38,700
+Dan: Or- or a riddle, really,
+[inaudible] Bekah.
+
+885
+00:46:37,000 --> 00:46:42,700
+Kirk: -[inaudible] sort of like
+fake icebreaker was which part
+
+884
+00:46:42,700 --> 00:46:43,210
+of -- not
 
 885
 00:46:43,211 --> 00:46:46,092
 which part of your body hurts.
-Cause the answer can be multiple
+Cuz the answer can be multiple.
 
 886
-00:46:46,331 --> 00:46:50,231
-will, like, which is the one
-you've noticed hurting like most
+00:46:46,331 --> 00:46:49,500
+Well, like, which is the one
+you've noticed hurting, like,
 
 887
-00:46:50,231 --> 00:46:53,922
-recently. Cause somehow we just
-all started talking to you about
+00:46:49,500 --> 00:46:53,500
+most, recently [chuckles]. Cuz
+somehow we just all started
 
 888
-00:46:53,922 --> 00:46:54,271
-the parts.
+00:46:53,500 --> 00:46:56,000
+talking about the parts of our
+body with, like, creaks.
 
 889
-00:46:55,496 --> 00:46:59,257
-Bekah: That's my traps. I trust
+00:46:56,300 --> 00:47:00,000
+Bekah: My traps [chuckles]. My
+traps hurt [chuckles].
 
 890
-00:47:00,447 --> 00:47:01,376
-Dan: which ones are your trucks?
+00:47:00,000 --> 00:47:01,376
+Dan: Which ones are your traps?
 
 891
-00:47:05,726 --> 00:47:09,777
-Bekah: I have builds up too much
-muscle, and now it's very tight
+00:47:02,000 --> 00:47:03,000
+Bekah: Here, back here.
 
 892
-00:47:10,257 --> 00:47:12,086
-and it hurts every day. No
-problem.
+00:47:03,300 --> 00:47:04,000
+Dan: Oh, okay.
 
 893
-00:47:14,817 --> 00:47:18,567
-Dan: I didn't do many trap
-exercises. So yeah,
+00:47:05,000 --> 00:47:09,700
+Bekah: I have built up too much
+muscle, and now it's very tight.
 
 894
-00:47:18,927 --> 00:47:21,416
-Kirk: when I was actually in
-school, I did all the triangle
+00:47:09,700 --> 00:47:10,500
+Dan: I have that problems too.
+
+892
+00:47:10,257 --> 00:47:11,700
+Bekah: And it hurts every day
+[laughs]. 
+
+893
+00:47:11,700 --> 00:47:12,500
+Kirk: You have that problem too,
+right, Dan? You just way too
+
+894
+00:47:12,500 --> 00:47:14,817
+much muscle. 
+
+893
+00:47:14,817 --> 00:47:17,700
+Dan: I didn't do many trapezoid
+exercises. So --
+
+894
+00:47:18,000 --> 00:47:20,000
+Kirk: Yeah. When I was a kid in
+school-
 
 895
-00:47:21,416 --> 00:47:22,186
-workouts I saw
+00:47:20,000 --> 00:47:20,500
+Dan: I just --
+
+895
+00:47:20,300 --> 00:47:22,500
+Kirk: -I did all the triangle
+workouts. I saw [inaudible] --
 
 896
-00:47:22,717 --> 00:47:24,167
-Dan: I get in the gym and I
-think geometry I'm like, you
+00:47:22,300 --> 00:47:24,167
+Dan: You know, I get in the gym
+and I think tri- geometry I'm
 
 897
-00:47:24,167 --> 00:47:25,617
-know, the
+00:47:24,167 --> 00:47:26,000
+like, "Yo, those trapezoids --"
 
 898
-00:47:25,617 --> 00:47:35,157
-strap designs Robinson's and you
-got to get the whole, the acute
+00:47:26,500 --> 00:47:26,700
+Kirk: Boom.
+
+899
+00:47:27,000 --> 00:47:28,500
+Bekah: What about your- what
+about your [inaudible]
+
+900
+00:47:28,500 --> 00:47:29,000
+trapezoids [chuckles]?
+
+898
+00:47:25,617 --> 00:47:31,000
+Dan: [Inaudible] trapezoids
+[inaudible].
+
+899
+00:47:31,000 --> 00:47:32,700
+Kirk: [Inaudible].
+
+900
+00:47:32,700 --> 00:47:35,300
+Dan: And you gotta get the- the
+whole, the acute-
+
+901
+00:47:35,300 --> 00:47:35,700
+Bekah: Quadercept squad.
 
 899
 00:47:35,336 --> 00:47:37,601
-and the acute and the up twos
-triangles, and then make sure
+Dan: -and the obtuse -- the
+acute and the obtuse triangles.
 
 900
-00:47:37,601 --> 00:47:39,866
-you
+00:47:37,601 --> 00:47:41,500
+And then make sure you hit the
+-- oh, sh-
 
 901
-00:47:39,867 --> 00:47:43,312
-hit the, what's the what's
-the perfect triangle. Equal
+00:47:41,500 --> 00:47:42,500
+Bekah: Squares [laughs].
 
 902
-00:47:43,312 --> 00:47:46,757
-equal
+00:47:42,500 --> 00:47:44,000
+Dan: Is it -- no. What's the-
+what's the per- is perfect
+
+902
+00:47:44,000 --> 00:47:47,036
+triangle -- well, no. What's
+the ... equal lateral. E-equal
 
 903
-00:47:47,036 --> 00:47:48,821
-lateral equal lateral triangle
+00:47:47,036 --> 00:47:50,000
+lateral- equal lateral triangle
 as well. Make sure you hit all
 
-904
-00:47:48,821 --> 00:47:50,606
-three
-
 905
-00:47:50,606 --> 00:47:52,976
-of those. If you want to do a
-full workout, then you get into
+00:47:50,000 --> 00:47:51,500
+three of those. If you wanna do-
+
+906
+00:47:51,500 --> 00:47:51,700
+Kirk: Yeah.
+
+907
+00:47:51,600 --> 00:47:52,976
+Dan: -a full workout, then you
+get
 
 906
 00:47:52,976 --> 00:47:55,181
-the 3d and you get some cubes
-and you know, you get some,
+into the 3D and you get some
+cubes. And, you know, you get
 
 907
 00:47:55,181 --> 00:47:57,386
-other
+some ... other
 
 908
-00:47:57,387 --> 00:48:00,717
-Hedron oh man, this is where I
-almost had it.
+00:47:57,387 --> 00:47:59,000
+hedron [??] things -- oh, man.
+This is where I [inaudible].
+
+909
+00:47:59,000 --> 00:48:00,000
+Kirk: This man is clearly --
+
+910
+00:48:00,000 --> 00:48:02,907
+Dan: I almost had it [laughs].
 
 909
 00:48:02,907 --> 00:48:06,387
-Kirk: And this is what we're
-saying. And then someone in the
+Kirk: And sports is what we're
+saying. I think someone in the
 
 910
 00:48:06,387 --> 00:48:10,286
-slack was like, who could lift
-more weight? Like who could like
+Slack was like, "Who could lift
+more weight?" Like, "Who could,
 
 911
 00:48:10,286 --> 00:48:12,717
-deadlift more? I'm like, it's,
-it's definitely that,
+like, deadlift more?" I'm like,
+"It's- it's definitely Bekah."
 
 912
-00:48:12,746 --> 00:48:15,927
-Dan: Deadlift, deadlift,
-Bekah would very easily. I mean,
+00:48:12,746 --> 00:48:15,500
+Dan: A deadlift- a deadlift --
+Bekah would very easily -- I
 
 913
-00:48:15,927 --> 00:48:18,447
-most of these probably she would
-anyway, but like a, a deadlift,
+00:48:15,500 --> 00:48:18,000
+mean, most of these probably she
+would anyway, but like a- a
 
 914
-00:48:18,956 --> 00:48:21,327
-any of the ones where you need a
-form, you need form and stuff.
+00:48:18,000 --> 00:48:20,700
+deadlift, any of the ones where
+you need a form -- we need form
 
 915
-00:48:21,327 --> 00:48:24,416
-Like that's all the proper form
-I'm saying I would just kill
+00:48:20,700 --> 00:48:21,327
+and stuff, like-
+
+916
+00:48:21,327 --> 00:48:22,300
+Kirk: That's all of them.
+
+917
+00:48:22,300
+Dan: -the proper form -- I'm
+saying, I would just kill
 
 916
 00:48:24,416 --> 00:48:26,051
-myself. Like I would like my
-back or something. You know what
+myself. Like, I would like -- my
+back would throw up or
 
 917
-00:48:26,051 --> 00:48:27,686
-I
+00:48:26,051 --> 00:48:28,300
+something. You know what I mean?
+I have
 
 918
-00:48:27,686 --> 00:48:32,157
-mean? I have literally never
-works out. Like I'm fairly
+00:48:28,300 --> 00:48:32,157
+[inaudible] literally never
+works out. Like, I'm fairly
 
 919
-00:48:32,157 --> 00:48:34,016
+00:48:32,157 --> 00:48:35,876
 strong, but Bekah works out all
-the time. If it is very strong,
-
-920
-00:48:34,016 --> 00:48:35,875
-I
+the time and it is very strong.
 
 921
-00:48:35,876 --> 00:48:37,853
-feel like a. I feel like a bench
-press is where, like, I feel
+00:48:35,876 --> 00:48:39,000
+I feel like a- I feel like a
+bench press is where I-
 
 922
-00:48:37,853 --> 00:48:39,830
-like
+00:48:39,000 --> 00:48:39,300
+Bekah: Yeah.
+
+922
+00:48:37,853 --> 00:48:41,700
+Dan: -like, I feel like a bench
+press, I probably could equal
 
 923
-00:48:39,831 --> 00:48:43,101
-a bench press, I probably could
-equal her because I don't have
+00:48:41,700 --> 00:48:42,000
+her.
+
+924
+00:48:42,000 --> 00:48:42,300
+Kirk: Okay.
+
+925
+00:48:42,300 --> 00:48:43,000
+Dan: I dunno- I don't-
+
+926
+00:48:42,700 --> 00:48:44,700
+Bekah: Oh, you for sure could ...
+kill me.
 
 924
 00:48:43,101 --> 00:48:46,371
-to
+Dan: -think you were -- but like
+-- be- because with bench press,
 
 925
-00:48:46,371 --> 00:48:49,641
-worry about hurting myself very
-badly because of my back. You
+00:48:46,371 --> 00:48:48,000
+I don't have to worry about
+hurting myself very badly
 
 926
-00:48:49,641 --> 00:48:52,791
-know what I mean? Then it's just
-like, and then it's, you know,
+00:48:48,000 --> 00:48:49,000
+[chuckles] cuz my back is
+supported.
 
 927
-00:48:53,632 --> 00:48:57,831
-but like any of the ones that
-like requires skill, I mean,
+00:48:48,500 --> 00:48:49,500
+Kirk: You could just sit. I
+mean, I've seen --
+
+926
+00:48:49,641 --> 00:48:51,700
+Dan: You know what I mean?
+[Laughs] Then it's just like --
+
+927
+00:48:51,700 --> 00:48:52,791
+and then it's ... you know?
+
+927
+00:48:53,632 --> 00:48:58,000
+But like, any of the ones that
+like requires skill? I mean,
 
 928
-00:48:58,461 --> 00:49:01,222
+00:48:58,000 --> 00:48:58,300
+she's-
+
+928
+00:48:58,461 --> 00:49:00,000
 Bekah: Jesse and I talked about
-it last night. I was like, I
+it last night.
 
 929
-00:49:01,222 --> 00:49:02,481
-think Dan could crush me in,
+00:49:00,000 --> 00:49:00,700
+Dan: -she's killing it.
+[Inaudible].
+
+929
+00:49:00,500 --> 00:49:02,481
+Bekah: I was like, "I think Dan
+could crush me in bench
 
 930
-00:49:02,911 --> 00:49:05,541
-Dan: I'm like for somebody
-who
+00:49:02,481 --> 00:49:03,000
+pressing."
+
+930
+00:49:02,911 --> 00:49:04,000
+Dan: I'm- I'm I'm sup- I'm like-
 
 931
-00:49:05,541 --> 00:49:09,561
-Kirk: doesn't ever work, but I
-want to know is wins cycling. I
+00:49:04,000 --> 00:49:04,700
+Bekah: He was on board for that.
+
+932
+00:49:04,300 --> 00:49:06,500
+Dan: -supposedly strong for
+somebody who doesn't ever work
+
+933
+00:49:06,500 --> 00:49:06,700
+out.
+
+931
+00:49:06,700 --> 00:49:09,561
+Kirk: What I wanna know is who
+wins in cycling. I
 
 932
 00:49:09,561 --> 00:49:10,882
@@ -5163,164 +6268,233 @@ think you could have an edge
 there.
 
 933
-00:49:11,722 --> 00:49:17,782
-Bekah: Oh, for sure. I don't
-know how to cycle stationary
+00:49:11,722 --> 00:49:12,300
+Bekah: Oh, for sure.
 
 934
-00:49:17,782 --> 00:49:22,311
-Kirk: bicycle after like elbow
-scar McGee over there. We've got
+00:49:12,300 --> 00:49:12,500
+Dan: Cycling?
+
+935
+00:49:12,500 --> 00:49:14,700
+Bekah: I- I don't know how to
+cycle [laughs].
+
+934
+00:49:14,700 --> 00:49:16,500
+Kirk: After, you know?
+
+935
+00:49:17,000 --> 00:49:18,500
+Bekah: Stationary bicycle?
+
+936
+00:49:19,000 --> 00:49:22,311
+Kirk: After, like, elbow scar
+McGee over there. You got a
 
 935
 00:49:22,311 --> 00:49:22,641
-to change
+chance.
 
 936
-00:49:23,052 --> 00:49:25,402
-Dan: if we're going to have it.
-So somebody mentioned triathlons
+00:49:22,500 --> 00:49:24,500
+Dan: Although, if we're going to
+have it -- so, somebody
 
 937
-00:49:25,402 --> 00:49:28,731
-and there's like triathlon teams
-too. So like they have like team
+00:49:24,500 --> 00:49:26,500
+mentioned triathlons. And
+there's like triathlon teams
 
 938
-00:49:28,731 --> 00:49:31,496
-for competition, you know, as
-well. So. If we did a triathlon,
+00:49:26,500 --> 00:49:28,300
+too. So every -- most
+triathlons-
 
 939
-00:49:31,496 --> 00:49:35,936
-would you do run or swim?
-Probably swim. All right. So
+00:49:28,300 -->00:49:28,500
+Bekah: Oh.
+
+938
+00:49:28,400 --> 00:49:29,700
+Dan: -they have like team for competition, you know, as well.
+
+939
+00:49:29,700 --> 00:49:33,700
+So, if we do a triathlon, would
+you do run or swim?
+
+939
+00:49:34,300 --> 00:49:35,000
+Bekah: Probably swim.
 
 940
-00:49:35,936 --> 00:49:37,617
-Kirk, that means you're on
-running.
+00:49:35,500 --> 00:49:37,617
+Dan: Alright. So Kirk, that
+means you're on running?
 
 941
-00:49:40,797 --> 00:49:49,677
+00:49:37,617 --> 00:49:40,000
+[Inaudible].
+
+941
+00:49:40,797 --> 00:49:45,500
 Kirk: What am I better at than
-the two of you jokes? Oh, be
+the two of you ... jokes? Ooh.
 
 942
-00:49:49,697 --> 00:49:51,237
-better at sports wise.
+00:49:45,500 --> 00:49:48,000
+Bekah: Ha-ha. Kirk.
+
+942
+00:49:49,000 --> 00:49:51,237
+Kirk: What am I better at sports
+wise?
 
 943
 00:49:51,806 --> 00:49:54,626
-Dan: No, Joe Bekah, when it
-pushups easily.
+Dan: No, Joe, Bekah would win at
+push-ups easily.
 
 944
-00:49:55,496 --> 00:49:58,907
-Bekah: Oh, I don't know. I, my
-shoulder is Kirk is still in the
+00:49:55,000 --> 00:49:55,300
+Kirk: Easy.
+
+944
+00:49:55,300 --> 00:49:58,500
+Bekah: Oh, I don't know. I -- my
+shoulder is -- Kirk is still in
 
 945
-00:49:58,907 --> 00:50:00,626
-a hundred push-ups challenge,
+00:49:58,500 --> 00:50:00,626
+the hundred push-ups challenge,
 right?
 
 946
 00:50:00,987 --> 00:50:03,447
 Kirk: Yeah. But I don't do like
-the full ones I'm doing like
+the full ones. I'm doing like
 
 947
-00:50:03,447 --> 00:50:04,016
-incline.
+00:50:03,447 --> 00:50:04,500
+incline. No shame.
 
 948
-00:50:05,847 --> 00:50:07,796
-Bekah: I, my, I hear my
+00:50:05,847 --> 00:50:08,500
+Bekah: I -- my -- I hear my
 shoulder. I have a torn
 
 949
-00:50:07,796 --> 00:50:09,745
-something. Yeah. My
-
-950
-00:50:09,746 --> 00:50:09,896
-thing
+00:50:08,500 --> 00:50:09,000
+something.
 
 951
-00:50:09,896 --> 00:50:12,416
-Dan: with, with pushups,
-honestly, that bothers me is my
+00:50:09,300 --> 00:50:11,300
+Dan: You know, my thing with-
+with push-ups, honestly, that
 
 952
-00:50:12,416 --> 00:50:13,856
-wrists are flexible for my
+00:50:11,300 --> 00:50:14,000
+bothers me, is my wrists aren't
+flexible. Therefore my wrist
 
 953
-00:50:13,856 --> 00:50:14,336
-Bekah: research.
+00:50:14,000 --> 00:50:14,500
+hurt-
+
+953
+00:50:14,500 --> 00:50:14,700
+Bekah: Oh, yeah-
 
 954
-00:50:16,737 --> 00:50:17,007
-Dan: Like they
+00:50:14,700 --> 00:50:15,500
+Dan: -from bending back. 
 
 955
-00:50:17,007 --> 00:50:20,246
-Bekah: don't like my right wrist
-from using the mask all the time
+00:50:14,800 --> 00:50:16,000
+Bekah: -you gotta work on that.
+
+954
+00:50:16,000 --> 00:50:18,000
+Dan: Yeah. Like, they don't,
+like --
+
+955
+00:50:18,000 --> 00:50:20,246
+Bekah: My right wrist, from
+using the mouse all the time,
 
 956
 00:50:20,246 --> 00:50:21,597
 is definitely tighter than my
-left
+left one.
 
 957
 00:50:21,597 --> 00:50:24,146
-Dan: one. I'm sure I could work
-on it if I want it to.
+Dan: Yeah. I'm sure I could work
+on it if I want it to. But,
 
 958
-00:50:24,177 --> 00:50:26,456
-Kirk: But yeah, the tunnel, the
-tunnel I traveled through the
+00:50:24,146 --> 00:50:24,300
+yeah.
+
+958
+00:50:24,700 --> 00:50:26,456
+Kirk: The tunnel- the tunnel I
+traveled through the most is
 
 959
-00:50:26,456 --> 00:50:30,461
-most as harmful for sure. They
-have those things, like those
+00:50:26,456 --> 00:50:30,000
+carpool [??], for sure. But,
+like, they have those things,
 
 960
-00:50:30,461 --> 00:50:33,311
-things you can hold instead of
-pressing your arms flat on the
+00:50:30,000 --> 00:50:32,700
+like, those things you can fold
+instead of pressing your arms
 
 961
-00:50:33,311 --> 00:50:35,936
-ground, they just, they hurt
-your arm in a different way. So
+00:50:32,700 --> 00:50:35,936
+flat on the ground. But they
+just -- they hurt-
 
 962
-00:50:35,936 --> 00:50:38,561
-I'm
+00:50:36,000 --> 00:50:36,300
+Bekah: Yeah.
+
+962
+00:50:36,300 --> 00:50:38,300
+Kirk: -just put your arm in a
+different way. So I'm like-
 
 963
-00:50:38,561 --> 00:50:40,541
-like this just transferred the
+00:50:38,300 --> 00:50:38,561
+Bekah: Yeah.
+
+963
+00:50:38,561 --> 00:50:42,300
+Kirk: -this just transferred the
 pain from like doing this to
 
-964
-00:50:40,541 --> 00:50:42,521
-like
-
 965
-00:50:42,521 --> 00:50:46,302
-straight through. So it doesn't
-help at all. Yeah. Did
+00:50:42,300 --> 00:50:45,500
+like straight through. So it
+doesn't help at all.
 
 966
-00:50:46,302 --> 00:50:49,931
-Dan: you read next pivot? No.
-Nick just says, I saw someone
+00:50:45,500 --> 00:50:47,000
+Dan: Yeah. Did you read Nick's
+comment?
+
+967
+00:50:46,500 -->00:50:48,000
+Bekah: Na- no.
+
+968
+00:50:48,500 --> 00:50:49,931
+Dan: Nick just says, "I saw
+someone
 
 967
 00:50:49,931 --> 00:50:52,481
@@ -5328,263 +6502,414 @@ mountain biking on a unicycle in
 a forest outside of Montreal. I
 
 968
-00:50:52,481 --> 00:51:00,356
-wave to them and they just
-imagine them like doing a jump
+00:50:52,481 --> 00:50:55,000
+wave to them and they fell. I
+laughed."
 
 969
-00:51:00,356 --> 00:51:08,231
-on
+00:50:55,700 --> 00:50:58,000
+Bekah: [All laugh] That's the
+joker of a true story.
+
+970
+00:50:57,000 --> 00:50:58,000
+Dan: Nick- Nick, that does sound
+--
+
+971
+00:50:58,500 --> 00:50:59,800
+Kirk: It's Montreal. So it's
+definitely [inaudible]
+
+972
+00:50:59,800 --> 00:51:04,000
+[all laugh]. My trip to go home
+[inaudible].
+
+973
+00:51:03,300 --> 00:51:07,000
+Dan: Oh, man. [Inaudible]. I
+just imagine them like doing a
+
+969
+00:51:07,000 --> 00:51:08,231
+jump [Bekah chuckles] on
 
 970
 00:51:08,231 --> 00:51:13,452
 a unicycle, waving to Nick, and
-then like seeing them veer off
+then, like, seeing them veer off
 
 971
 00:51:13,452 --> 00:51:15,492
-into a tree and yelling soccer,
-light blue or something.
+into a tree and yelling "Sacré
+bleu," or something like that
 
 972
-00:51:16,601 --> 00:51:19,001
-Kirk: It's like the office. They
-have to yell our core, our
+00:51:15,492 --> 00:51:16,000
+[laughs].
+
+972
+00:51:16,601 --> 00:51:18,500
+Kirk: It's like "The Office".
+They have to yell, "Parkour!
+
+973
+00:51:18,500 --> 00:51:19,001
+Parkour!"
 
 973
 00:51:19,001 --> 00:51:21,072
-Bekah: core. Oh my gosh. My kids
-love that
+Bekah: Oh, my gosh. My kids
+love that.
 
 974
-00:51:22,512 --> 00:51:23,081
-Kirk: that'll away.
+00:51:22,512 --> 00:51:23,500
+Kirk: Then, it'll away. No --
 
 975
-00:51:24,731 --> 00:51:25,001
-Bekah: Yeah.
+00:51:23,500 --> 00:51:26,001
+Bekah: A mountain bike unicycle?
+I didn't even know it was a thing.
 
 976
-00:51:26,231 --> 00:51:28,136
-Dan: I've seen those for sure.
-So people do like insane things
+00:51:24,500 --> 00:51:25,700
+Dan: Yeah, yeah, yeah. No. I've
+don't -- I've seen -- I've- I've
 
 977
-00:51:28,136 --> 00:51:30,041
-on
+00:51:25,700 --> 00:51:29,000
+seen those for sure. A-and,
+like, the people do, like,
+
+977
+00:51:29,000 --> 00:51:32,000
+insane things on them. I've-
+I've seen them once. Oh,
 
 978
-00:51:30,041 --> 00:51:31,886
-them. I've I've seen him. I
-don't think I've seen them in
-
-979
-00:51:31,886 --> 00:51:33,731
-real
+00:51:32,000 --> 00:51:34,500
+I- I don't think I've seen them
+in real life, but I've seen them
 
 980
-00:51:33,731 --> 00:51:37,302
-life, but I've seen them on
-YouTube. If you want some,
+00:51:34,500 --> 00:51:38,500
+on YouTube. If you want to know
+more, let me do --
 
 981
-00:51:38,262 --> 00:51:40,722
-Kirk: you know, on Spiderman or
-they tell them, do a flip and
+00:51:37,000 --> 00:51:39,700
+Kirk: I want to -- you know, on 
+Spiderman, when they tell him
 
 982
-00:51:40,722 --> 00:51:42,326
-then he does the flip and then
-it was like, oh, that's it. I
+00:51:39,700 --> 00:51:42,300
+do a flip, and then he does the
+flip, and then he was like "Oh,
 
 983
-00:51:42,326 --> 00:51:43,930
-want
+00:51:42,300 --> 00:51:42,500
+that's-
 
 984
-00:51:43,931 --> 00:51:46,152
-it to be on like, both ends of
-that. I don't want to be the
+00:51:42,500 --> 00:51:42,700
+Dan: Yeah.
+
+983
+00:51:42,600 --> 00:51:45,000
+Kirk: -so cool." I want to be
+on, like, both ends
+
+984
+00:51:45,000 --> 00:51:47,500
+of that. I wanna be the person
+saying do the flip and
 
 985
-00:51:46,152 --> 00:51:49,032
-person saying, do the flip. And
+00:51:47,500 --> 00:51:51,300
 then someone else does the flip.
+And someone says to me, I wanna
 
 986
-00:51:49,331 --> 00:51:50,981
-And someone says to me, I want
-to be able to do the flip in
+00:51:51,300 --> 00:51:53,000
+be able to do the flip in
+that moment.
 
 987
-00:51:50,981 --> 00:51:52,631
-that
+00:51:52,500 --> 00:51:53,500
+Dan: Yeah. Yeah, yeah.
 
 988
-00:51:52,632 --> 00:51:56,231
-moment. But that's never
-going to happen. You're
+00:51:54,000 --> 00:51:56,231
+Kirk: But that's never gonna
+happen. Just, backflips are
 
 989
 00:51:56,231 --> 00:51:59,172
-terrified. What am I better at
-than the two of you? This is, I
+terrifying. What am I better at
+than the two of you? This is --
 
 990
 00:51:59,172 --> 00:51:59,831
-gotta figure this
+I gotta figure this out.
 
 991
-00:51:59,831 --> 00:52:08,952
-Bekah: out. Kindness
-documentation. Well, I don't
+00:52,000 --> 00:52:03,700
+Bekah: Kindness [chuckles],
+documentation-
 
 992
-00:52:08,952 --> 00:52:12,882
-know if Dan's better than you at
-games or not. I like games. I'm
+00:52:04,000 --> 00:52:04,300
+Kirk: No.
 
 993
-00:52:12,882 --> 00:52:13,692
-very bad at them.
+00:52:04,500 --> 00:52:05,000
+Bekah: -Elm-
 
 994
-00:52:18,942 --> 00:52:21,431
-Kirk: Not anymore. That's
+00:52:05,700 --> 00:52:06,000
+Kirk: Yes.
 
 995
-00:52:21,911 --> 00:52:22,601
-Bekah: have you seen the.
+00:52:06,000 --> 00:52:06,300
+Bekah: -games.
 
 996
-00:52:23,996 --> 00:52:26,951
+00:52:07,000 --> 00:52:08,000
+Kirk: Hmm.
+
+992
+00:52:08,952 --> 00:52:10,700
+Bekah: Well, I don't know if
+Dan's better than you at games
+
+993
+00:52:10,700 --> 00:52:13,692
+or not. I like games, and very
+bad at them.
+
+994
+00:52:14,000 --> 00:52:16,700
+Kirk: I only like like two
+things. But I've -- it's --
+
+995
+00:52:16,700 --> 00:52:17,000
+Bekah: Yoga.
+
+996
+00:52:18,000 --> 00:52:21,700
+Kirk: Hmm. Not anymore. That's
+--
+
+995
+00:52:21,911 --> 00:52:23,700
+Bekah: Have you seen Dan do
+yoga?
+
+996
+00:52:23,996 --> 00:52:29,000
 Kirk: I would pay money. I
-would, I would donate time and
+would- I would donate time and
 
 997
-00:52:26,951 --> 00:52:29,906
-money to
+00:52:29,000 --> 00:52:31,000
+money to make that happen
+[Bekah chuckles].
 
 998
-00:52:29,907 --> 00:52:30,237
-make that
+00:52:31,000 --> 00:52:32,000
+Dan: I'm --
 
 999
-00:52:32,246 --> 00:52:33,656
-Bekah: Kurt, Kurt is Kirk Day.
-You were allowed to ask him to
-
-1000
-00:52:33,656 --> 00:52:35,066
-do
+00:52:32,246 --> 00:52:34,500
+Bekah: Kirk, Kirk, it is Kirk
+Day. You are allowed to ask him
 
 1001
-00:52:35,067 --> 00:52:36,447
-whatever you want right now.
+00:52:34,500 --> 00:52:35,700
+to do whatever you want-
 
 1002
-00:52:43,226 --> 00:52:46,137
-Dan: I don't know. I just, I'm
-not very flexible at all that
+00:52:35,700 --> 00:52:37,500
+Dan: Listen, I'm not doing any
+[inaudible] right now.
 
 1003
-00:52:46,817 --> 00:52:47,757
-it's a known fact.
+00:52:35,800 --> 00:52:38,000
+Bekah: -right now, okay? No,
+we're not [??].
 
 1004
-00:52:48,567 --> 00:52:52,797
-Bekah: Kirk poetry, maybe. I
-don't know.
+00:52:37,500 --> 00:52:40,000
+Kirk: Not like the day of my
+daughter's weddings [??]
 
 1005
-00:52:53,396 --> 00:52:55,376
-Kirk: Are you you're, you're a
-poet. You poet.
+00:52:40,000 --> 00:52:41,000
+[laughs]. Thank god.
+
+1002
+00:52:41,500 --> 00:52:45,000
+Dan: [Inaudible]. I don't know.
+No, I just -- I'm not very
+
+1003
+00:52:45,000 --> 00:52:47,757
+flexible at all that. I'm --
+it's- it's a known fact.
+
+1004
+00:52:47,757 --> 00:52:49,000
+Bekah: Haikus, Kirk. 
+
+1005
+00:52:49,000 --> 00:52:50,000
+Kirk: Oh, yeah.
 
 1006
-00:52:58,976 --> 00:53:02,697
-Bekah: We have debt. We have all
-three devils in the poetry. You
+00:52:50,500 --> 00:52:53,000
+Bekah: Poetry. Maybe. I don't
+know.
+
+1005
+00:52:53,396 --> 00:52:55,500
+Kirk: Well, you -- you're-
+you're a poet. You poet. You
+
+1006
+00:52:55,500 --> 00:52:55,700
+poem.
+
+1006
+00:52:56,000 --> 00:52:57,500
+Bekah: Yeah. For sure, yeah
+[laughs].
 
 1007
-00:53:02,697 --> 00:53:04,616
-may be able to find all three of
-our poetry online. If you
+00:52:57,500 --> 00:52:58,700
+Dan: We all have dabbled in the
+poetry.
 
 1008
-00:53:04,616 --> 00:53:06,535
-search,
+00:52:59,000 --> 00:53:02,000
+Bekah: We've dab- we have all
+three dabbled in the poetry.
 
 1009
-00:53:08,666 --> 00:53:10,061
+00:53:02,000 --> 00:53:02,300
+Dan: I have --
+
+1110
+00:53:02,300 --> 00:53:02,500
+Kirk: One day --
+
+1007
+00:53:02,697 --> 00:53:05,500
+Bekah: You may be able to find
+all three of our poetry online.
+
+1008
+00:53:05,500 --> 00:53:08,300
+If you search hard enough
+[Bekah and Dan laugh].
+
+1009
+00:53:08,666 --> 00:53:11,300
 Kirk: I used to have a website.
 The first website I ever made
 
 1010
-00:53:10,061 --> 00:53:11,456
+00:53:11,300 --> 00:53:11,456
 was
 
 1011
 00:53:11,456 --> 00:53:16,121
-a WordPress site. It was called.
-Shiver sharks. Cause that's a
+a WordPress site. It was called
+Shiver Sharks. Cuz that's a
 
 1012
-00:53:16,121 --> 00:53:19,001
-collective noun for sharks. And
-I found out cause everyone does
+00:53:16,121 --> 00:53:18,700
+collective noun for sharks, and
+I found out. Cuz everyone else
 
 1013
-00:53:19,001 --> 00:53:21,882
-like a pirate bowels or like
-one-on-ones everyone knows. I'm
+00:53:18,700 --> 00:53:21,882
+does like a poet of owls or
+like one on ones everyone
 
 1014
-00:53:21,882 --> 00:53:25,601
-like, give me a weird shiver or
-something like that. And then I
+00:53:21,882 --> 00:53:23,700
+knows. So, I'm like, "Give me a
+weird ones like a shiver or
+
+1015
+00:53:23,700 --> 00:53:25,601
+something like that." Great. And
+then I
 
 1015
 00:53:25,601 --> 00:53:29,771
-met the, I saw someone who had
-the murder of crows and I was
+met the -- I saw someone who had
+the murder of crows, and I was
 
 1016
-00:53:29,771 --> 00:53:38,351
-like boring them about that. But
-my websites, I don't want to
+00:53:29,771 --> 00:53:34,500
+like, "Boring." I really judged
+them about that. But my
 
 1017
-00:53:38,351 --> 00:53:46,422
-happen to it. WordPress is just
-like, you don't do enough. And I
+00:53:34,500 --> 00:53:38,351
+website's gone. So [all laugh].
+I don't know what happened
+
+1017
+00:53:38,351 --> 00:53:42,000
+to it. WordPress was just like,
+"You don't do enough."
 
 1018
-00:53:46,422 --> 00:53:52,362
-think I saved, I think I saved
-everything from it as a RTF rich
+00:53:42,000 --> 00:53:43,000
+[Inaudible].
 
 1019
-00:53:52,362 --> 00:53:59,141
-text. I'm like, this is great.
-Lost that file. Worthless
+00:53:44,700 --> 00:53:45,000
+Dan: Hm.
 
 1020
-00:54:00,702 --> 00:54:03,161
-unhelpful. This was before I
-knew about mark down or
+00:53:45,300 --> 00:53:45,700
+Bekah: Oh, no.
+
+1018
+00:53:46,000 --> 00:53:49,000
+Kirk: And I think I saved- I
+think I saved everything from it
+
+1019
+00:53:49,000 --> 00:53:58,000
+as a RTF Rich Text. I'm like,
+"This is great." Lost that file.
+
+1020
+00:53:58,000 --> 00:54:04,700
+Worthless. Unhelpful. This was
+before I knew about markdown or
 
 1021
-00:54:03,161 --> 00:54:05,620
-anything.
-
-1022
-00:54:05,922 --> 00:54:06,371
-Really?
+00:54:04,700 --> 00:54:06,000
+anything, really.
 
 1023
 00:54:07,722 --> 00:54:08,112
 Bekah: Yeah.
+
+1024
+00:54:08,112 --> 00:54:09,000
+Dan: Yeah.
+
+1025
+00:54:09,000 --> 00:54:10,000
+Bekah: Same.
 
 1024
 00:54:10,646 --> 00:54:13,827
@@ -5593,157 +6918,191 @@ thing we used to use to make
 
 1025
 00:54:13,827 --> 00:54:19,376
-websites? My professor in
-university used it. It flips
+websites? Ah. My professor in
+university used it. Eclipse --
 
 1026
-00:54:19,436 --> 00:54:20,817
-no three waiver.
+00:54:19,436 --> 00:54:20,000
+no. 
+
+1027
+00:54:20,000 --> 00:54:20,817
+Dan: Dreamweaver?
+
+1028
+00:54:21,000 --> 00:54:21,700
+Bekah: I love Dreamweaver.
+
+1029
+00:54:21,300 --> 00:54:23,000
+Kirk: Dreamweaver!
 
 1027
 00:54:23,967 --> 00:54:26,456
 Bekah: That was the first time I
-ever coded was in Dreamweaver.
+ever code, it was in Dreamweaver.
 
 1028
 00:54:26,487 --> 00:54:26,666
-Yeah,
+Dan: Yeah.
 
 1029
-00:54:29,336 --> 00:54:29,757
-Dan: for sure.
+00:54:27,000 --> 00:54:27,300
+Kirk: Yes.
+
+1029
+00:54:27,700 --> 00:54:30,000
+Dan: Yeah. I spent years in
+Dreamweaver, for sure.
 
 1030
-00:54:31,947 --> 00:54:34,677
-Bekah: I want to do yoga with
-the goat to Virtual Coffee
+00:54:30,000 --> 00:54:31,500
+Kirk: It was --
+
+1030
+00:54:31,947 --> 00:54:34,000
+Bekah: I wanna do yoga with
+the goat too.
 
 1031
-00:54:34,677 --> 00:54:37,407
-retreat at
+00:54:34,000 --> 00:54:34,500
+Kirk: What?
 
-1032
-00:54:37,407 --> 00:54:37,797
-Glenn's
+1031
+00:54:34,500 --> 00:54:38,500
+Bekah: Vir- Virtual Coffee
+retreat at Glenn's house.
 
 1033
-00:54:37,797 --> 00:54:42,447
-Kirk: house. I've seen the goat
-yoga videos. And as somebody who
+00:54:38,500 --> 00:54:42,447
+Kirk: I've seen the goat yoga
+videos. And as somebody who,
 
 1034
-00:54:42,447 --> 00:54:46,257
-like I see goats every day go
-prove it. That's a real
+00:54:42,447 --> 00:54:45,500
+like -- I see goats every day,
+goats poop.
 
 1035
-00:54:46,257 --> 00:54:49,362
-Dan: thing. Yeah. It's the go-to
-and yoga tour is to go just
+00:54:45,500 --> 00:54:46,257
+Dan: That's a real thing.
 
 1036
-00:54:49,362 --> 00:54:52,467
-like,
+00:54:46,700 --> 00:54:47,000
+Bekah: Yeah.
 
 1037
-00:54:54,327 --> 00:54:56,757
-Kirk: and a bunch of little like
-kid goats, just kind of like
+00:54:48,000 --> 00:54:49,300
+Kirk: Goats poop.
 
 1038
-00:54:56,786 --> 00:54:59,666
-amble about, and sometimes they
-just climb you. Cause that's
+00:54:49,700 --> 00:54:52,500
+Dan: Is the goat doing and yoga
+too or is the goat just like --
+
+1037
+00:54:52,500 --> 00:54:56,000
+Kirk: You do the yoga, and a
+bunch of little like kid goats,
+
+1038
+00:54:56,000 --> 00:54:58,700
+just kind of, like, amble about,
+and sometimes they just climb
 
 1039
-00:54:59,666 --> 00:55:00,717
-their thing. Oh,
+00:54:58,700 --> 00:55:00,717
+you cuz that's their thing.
 
 1040
 00:55:00,717 --> 00:55:01,286
-Dan: sure. I mean,
+Dan: Oh, sure. I mean that --
+yeah.
 
 1041
-00:55:01,556 --> 00:55:03,026
-Bekah: yeah. Can we do a
+00:55:01,556 --> 00:55:03,700
+Bekah: Can we do it with
 fainting goats too? And then we
 
 1042
-00:55:03,026 --> 00:55:04,496
-like jump
+00:55:03,700 --> 00:55:05,500
+could, like, jump up and scare
+'em?
 
 1043
-00:55:04,496 --> 00:55:05,277
-up and scare them.
+00:55:06,000 --> 00:55:06,500
+Dan: Fireworks.
 
 1044
-00:55:08,396 --> 00:55:10,916
-Dan: Yeah, Nick, I use fibers.
-Yeah, dreamer. So that's the
+00:55:06,300 --> 00:55:07,300
+Kirk: You're mean to the goats.
+
+1044
+00:55:08,396 --> 00:55:10,500
+Dan: Yeah, Nick, I use
+Fireworks. Yeah, Dreamewea- so
 
 1045
-00:55:10,916 --> 00:55:14,367
-Macromedia suite, like
-Dreamweaver fireworks, and then
+00:55:10,500 --> 00:55:12,000
+that's the Macromedia suite,
+like-
 
 1046
-00:55:14,367 --> 00:55:17,936
-like flash, if you do a flash
-and, there was another one
+00:55:12,000 --> 00:55:12,700
+Bekah: Oh, yeah.
 
 1047
-00:55:17,936 --> 00:55:19,466
-that I didn't use very much,
-like a more, designing one,
+00:55:13,000 --> 00:55:14,700
+Dan: -Dreamweaver, Fireworks,
+and then like Flash, if you do a
 
-1048
-00:55:19,466 --> 00:55:20,996
-but,
+1046
+00:55:14,700 --> 00:55:19,000
+Flash. And ... there was another
+one that I didn't use very much,
+
+1047
+00:55:19,000 --> 00:55:21,387
+like a more of designing one.
+But
 
 1049
-00:55:21,387 --> 00:55:22,857
-yeah, I wasn't doing more
-than farmers and like
-
-1050
-00:55:22,857 --> 00:55:24,327
-Dreamweaver
+00:55:21,387 --> 00:55:24,000
+... yeah. I was in Dreamweavers,
+Fireworks -- and, like,
 
 1051
-00:55:24,327 --> 00:55:26,381
-was actually really good.
-Even not using the like
+00:55:24,000 --> 00:55:27,500
+Dreamweaver was actually really
+good. Even not using the, like,
 
 1052
-00:55:26,381 --> 00:55:28,435
+00:55:28,000 --> 00:55:28,435
 generated
 
 1053
-00:55:28,436 --> 00:55:30,026
-stuff, but it was a good like
-code editor. Like I used it as
+00:55:28,436 --> 00:55:30,500
+stuff, but it was a good, like,
+code editor. Like, I used it-
 
 1054
-00:55:30,026 --> 00:55:31,616
-my
+00:55:30,500 --> 00:55:30,700
+Bekah: Yeah.
 
 1055
-00:55:31,617 --> 00:55:34,856
-like, just code editor for, I
-dunno, I dunno when it stopped,
+00:55:31,000 --> 00:55:34,856
+Dan: -as my, like, just code
+editor for -- I dunno. I dunno
 
 1056
-00:55:34,887 --> 00:55:35,367
-but like a long
+00:55:34,887 --> 00:55:35,500
+when I stopped. But like a long
+time.
 
 1057
-00:55:35,367 --> 00:55:37,347
-Bekah: time. Well, my first job
-out of my first full-time job
-
-1058
-00:55:37,347 --> 00:55:39,327
-out
+00:55:35,700 --> 00:55:39,327
+Bekah: Well, my first job out of
+-- my first full-time job out
 
 1059
 00:55:39,327 --> 00:55:41,786
@@ -5751,82 +7110,80 @@ of college, I was a community
 organizer for an environmental
 
 1060
-00:55:41,786 --> 00:55:46,887
-non-profit and the executive
-director, my first week, he was
+00:55:41,786 --> 00:55:44,000
+non-profit. And the executive
+director-
 
 1061
-00:55:46,887 --> 00:55:49,512
-like, do you know. How to use,
-how do you know a code? Like,
+00:55:44,000 --> 00:55:44,700
+Kirk: F-tracks [??].
 
 1062
-00:55:49,512 --> 00:55:52,137
-no,
+00:55:45,000 --> 00:55:46,887
+Bekah: -my first week, he was
+
+1061
+00:55:46,887 --> 00:55:51,300
+like, "Do you know how to use --
+how -- do you know code?" Like,
 
 1063
-00:55:52,706 --> 00:55:54,281
-he's like, okay, go home this
-weekend and learn HTML and CSS.
+00:55:51,300 --> 00:55:54,700
+"No." He was like, "Okay. Go
+home this weekend and learn HTML
 
 1064
-00:55:54,281 --> 00:55:55,856
-I
-
-1065
-00:55:55,867 --> 00:55:58,036
-was like, okay, like Jesse was
-my boyfriend at the time. And I
+00:55:54,700 --> 00:55:58,700
+and CSS. And I was like, "Okay."
+Like, Jesse was my boyfriend at
 
 1066
-00:55:58,036 --> 00:56:00,205
-went
+00:55:58,700 --> 00:56:02,500
+the time. And I went home and he
+had like textbooks on HTML and
 
 1067
-00:56:00,206 --> 00:56:03,447
-home and he had like textbooks
-on HTML and CSS. So then we went
+00:56:02,500 --> 00:56:04,700
+CSS. So then we went over those
+things, and like, "All right, I
 
 1068
-00:56:03,447 --> 00:56:05,967
-over those things like, all
-right, I know it. I know it now.
+00:56:04,700 --> 00:56:05,967
+know it. I know it now
+[laughs]."
 
 1069
-00:56:07,657 --> 00:56:10,476
-Kirk: That's awesome. All
-weekend. I'm pretty much an
+00:56:07,300 --> 00:56:07,700
+Dan: That's awesome.
+
+1069
+00:56:08,000 --> 00:56:10,476
+Kirk: It took all weekend. I'm
+pretty much an expert.
 
 1070
-00:56:10,476 --> 00:56:11,347
-expert. Nailed
-
-1071
-00:56:11,347 --> 00:56:11,436
-Dan: it.
+00:56:10,476 --> 00:56:12,000
+Dan: Nailed it. Yep. Yeah.
 
 1072
-00:56:13,146 --> 00:56:14,901
-Kirk: Just to say, Jeff,
-Jeff in the chat was like, do
-
-1073
-00:56:14,901 --> 00:56:16,656
-pushups
+00:56:13,146 --> 00:56:16,300
+Kirk: Just to say, Jeff- Jeff,
+in the chat, was like, "Do
 
 1074
-00:56:16,657 --> 00:56:19,072
-on your fists or wristband
-again, like we're just trading
+00:56:16,300 --> 00:56:19,072
+push-ups on your fists, no full
+wrist bend." Again, like, we're
 
 1075
-00:56:19,072 --> 00:56:21,487
-problems
+00:56:19,072 --> 00:56:22,000
+just trading problems here
+[Bekah chuckles].
 
 1076
-00:56:21,487 --> 00:56:29,257
-here. That's not, that's not
-better. Yeah. Shout out to
+00:56:23,000 --> 00:56:29,467
+That's not- that's not better.
+Yeah. Shoutout to --
 
 1077
 00:56:29,467 --> 00:56:32,077
@@ -5835,558 +7192,762 @@ like a lot of purple. It was all
 
 1078
 00:56:32,077 --> 00:56:35,257
-like purple involved with
-somebody. Oh, I have a great bad
+like purple involved for some
+reason. Oh, I have a great bad
 
 1079
 00:56:35,257 --> 00:56:38,047
 joke. I just heard it. This is
-apparently very popular with the
+apparently very popular, but
 
 1080
-00:56:38,077 --> 00:56:44,067
-first time I heard it. Bekah
-don't ruin it. Which are
+00:56:38,077 --> 00:56:41,300
+it's the first time I heard it.
+Bekah, don't ruin it.
 
 1081
-00:56:44,067 --> 00:56:50,757
-Kirk's could apply to all Java
-developers wear glasses.
+00:56:41,300 --> 00:56:41,500
+Bekah: Okay.
+
+1082
+00:56:43,700 --> 00:56:44,000
+Kirk: Which --
+
+1081
+00:56:44,067 --> 00:56:44,700
+Dan: Or Kirk's gonna fire you.
+
+1082
+00:56:45,000 --> 00:56:46,500
+Kirk: I -- do-
+
+1083
+00:56:46,500 --> 00:56:47,000
+Bekah: Kirk doesn't fire me.
+
+1084
+00:56:47,000 --> 00:56:51,000
+Kirk: -all Java developers wear
+glasses?
 
 1082
 00:56:53,876 --> 00:56:55,527
-Dan: This is where you say, I
-don't know why,
+Dan: This is where you say, "I
+don't know why."
 
 1083
-00:57:00,777 --> 00:57:02,757
-Kirk: because they can't see
-sharp.
+00:56:56,000 --> 00:56:59,000
+Bekah: Oh. [Dan chuckles] I
+don't know why.
+
+1083
+00:56:59,000 --> 00:57:02,757
+Kirk: That was really good.
+Because they can't 'see sharp'.
 
 1084
-00:57:04,166 --> 00:57:08,306
-Bekah: Nice. I was not
+00:57:04,166 --> 00:57:05,000
+Dan: Aah.
+
+1084
+00:57:05,000 --> 00:57:08,306
+Bekah: Ooh, nice. I was not
 going in that direction. I was
 
 1085
 00:57:08,306 --> 00:57:08,847
-going more with,
+going more with --
 
 1086
-00:57:09,117 --> 00:57:13,106
-Kirk: if, if you were a software
+00:57:09,117 --> 00:57:12,700
+Kirk: If- if you were a software
 developer in like 1998, that
 
 1087
-00:57:13,106 --> 00:57:17,487
-would have been incredibly like
-back when they were basically
+00:57:12,700 --> 00:57:16,000
+would have been incredibly
+[inaudible][chuckles]. Like,
 
 1088
-00:57:17,757 --> 00:57:22,706
-Dan: C sharp in 1998. This is
-like C plus plus in that, when
+00:57:16,000 --> 00:57:17,487
+back when they were basically
+like --
+
+1088
+00:57:17,757 --> 00:57:22,000
+Dan: I never heard of C# in
+1998. This is like C++ isn't it?
 
 1089
-00:57:22,706 --> 00:57:23,967
-did C-sharp become a thing.
+00:57:22,500 --> 00:57:23,967
+When did C# become a thing?
 
 1090
-00:57:24,356 --> 00:57:29,547
-Kirk: Okay. 2005. That's again,
-back when
+00:57:24,356 --> 00:57:29,700
+Kirk: Okay. 2005. That's, again,
+you know, back when like --
 
 1091
-00:57:31,697 --> 00:57:31,996
-Bekah: what's that
+00:57:29,500 --> 00:57:31,996
+Bekah: Well, you're like
+13. You didn't hear anything.
 
 1092
-00:57:31,996 --> 00:57:36,077
-Dan: 13, we don't need to talk
-about how old I was, but, I
+00:57:31,996 --> 00:57:34,000
+Dan: I wasn't 13. We don't need
+to talk about how old I was,
 
 1093
-00:57:36,077 --> 00:57:38,536
-wasn't, I was a computer science
-in college, which was after that
+00:57:34,000 --> 00:57:37,500
+but I wasn't -- I was in
+computer science in college,
 
 1094
-00:57:38,956 --> 00:57:39,286
-and.
+00:57:37,500 --> 00:57:39,286
+which was after that. And --
 
 1095
-00:57:41,606 --> 00:57:42,177
-Kirk: That's all the
+00:57:39,286 --> 00:57:41,700
+Kirk: Nick Taylor's heard it
+though. That's all the
 
 1096
-00:57:42,177 --> 00:57:46,556
-Dan: validation, I suppose, does
-not exist anymore.
+00:57:41,700 --> 00:57:43,000
+validation I need.
 
 1097
-00:57:47,186 --> 00:57:55,077
+00:57:42,700 --> 00:57:47,000
+Dan: C++. Does C++ not exist
+anymore?
+
+1097
+00:57:47,186 --> 00:57:51,500
 Kirk: Yeah. People use it to
-write. Whoa, whoa, buddy.
+write-
 
 1098
-00:57:55,387 --> 00:57:58,327
-Dan: I don't know. I'm asking.
-I'm not saying there's no
+00:57:51,500 --> 00:57:52,700
+Dan: What's the difference
+between that and C#?
 
 1099
-00:57:58,327 --> 00:58:00,697
-difference. I'm literally
-asking, I don't know. C
+00:57:52,700 --> 00:57:55,387
+Kirk: -Unity -- whoa, whoa,
+buddy.
+
+1098
+00:57:55,387 --> 00:57:56,500
+Dan: I don't know. I'm asking.
+
+1099
+00:57:56,500 --> 00:57:57,000
+Bekah: How dare you.
 
 1100
-00:58:00,697 --> 00:58:02,572
-Kirk: sharp is all.net, right?
-It's all Microsoft, right?
+00:57:57,000 --> 00:57:57,500
+Kirk: I mean --
 
 1101
-00:58:02,572 --> 00:58:04,447
-That's
+00:57:57,500 --> 00:57:58,700
+Dan: I'm not- I'm not saying
+there's no difference. I'm
+
+1099
+00:57:58,700 --> 00:58:00,000
+literally asking. I don't know.
+
+1100
+00:58:00,000 --> 00:58:02,572
+Kirk: C# is all .NET, right?
+It's all Microsoft.
+
+1101
+00:58:02,572 --> 00:58:03,000
+Dan: Oh, okay.
+
+1101
+00:58:03,572 --> 00:58:04,447
+Kirk: Right? That's this --
 
 1102
-00:58:04,447 --> 00:58:08,586
-this, if you're in Microsoft,
-90% of the time you're writing C
+00:58:05,000 --> 00:58:09,000
+if you're in Microsoft, 90% of
+the time you're writing C#.
 
 1103
-00:58:08,586 --> 00:58:15,067
-sharp, and C plus plus is
-not, C plus plus is still
+00:58:09,000 --> 00:58:14,700
+And C++ is not. C++ is still
 
 1104
-00:58:15,067 --> 00:58:18,652
-considered like the Lang for
-like high-performance stuff. If
-
-1105
-00:58:18,652 --> 00:58:22,237
-you
+00:58:14,700 --> 00:58:21,700
+considered like the lang du jour
+for like high-performance stuff
 
 1106
-00:58:22,237 --> 00:58:27,606
-don't want to get down to see, I
-guess, but I feel like C plus
+00:58:21,700 --> 00:58:27,606
+if you don't wanna get down to
+C, I guess. But I feel like C++
 
 1107
-00:58:27,606 --> 00:58:31,931
-plus dad's favorite thing to do
-is like, complain about. Yeah.
+00:58:27,606 --> 00:58:30,500
+dad's favorite thing to do
+is like complain about C++
+
+1108
+00:58:30,500 --> 00:58:30,700
+[chuckles].
+
+1109
+00:58:30,700 --> 00:58:31,000
+Dan: [Chuckles] Sure.
 
 1108
 00:58:31,931 --> 00:58:32,621
-Like JavaScript,
+Kirk: Kinda like JavaScript
+devs.
 
 1109
-00:58:33,461 --> 00:58:34,406
-Dan: if you get to a certain
-level, that's just going to be
+00:58:32,621 --> 00:58:34,406
+Dan: Like, yeah, you -- if you
+get to a certain level, that's
 
 1110
 00:58:34,406 --> 00:58:35,351
-an
+just gonna be --
 
 1111
 00:58:35,351 --> 00:58:37,871
-Kirk: ally. If it's useful
-enough, like there'll be enough
+Kirk: Yeah. Like, if it's useful
+enough, like, there'll be enough
 
 1112
-00:58:37,871 --> 00:58:39,326
-code written that it was like
+00:58:37,871 --> 00:58:40,300
+code written, that there isn't
 something to complain about.
 
-1113
-00:58:39,326 --> 00:58:40,781
-Like
-
 1114
-00:58:40,782 --> 00:58:43,407
-Dan: Emily tells people, like
-she was on a trip with her
+00:58:40,782 --> 00:58:44,700
+Dan: Like, Emily ... tells
+people -- like, sh- she was a --
 
 1115
-00:58:43,407 --> 00:58:46,032
-grandma
+00:58:44,700 --> 00:58:45,700
+on a trip with her grandma
 
 1116
-00:58:46,061 --> 00:58:49,092
-and she's like, yeah, Dan hates
-computers. And she knows that
+00:58:45,700 --> 00:58:49,092
+and she's like, "Yeah, Dan hates
+computers." And she knows that,
 
 1117
 00:58:49,092 --> 00:58:51,822
-like, this is what I do for a
-living, you know, but it's true.
+like, I do this -- I do this
+for a living, you know? But it's
 
 1118
-00:58:53,411 --> 00:58:55,692
-You know, she didn't understand,
-you know, she's like, what, what
+00:58:51,822 --> 00:58:54,300
+true. [Laughs] I'm like -- I
+just -- she- she didn't
 
 1119
-00:58:55,692 --> 00:58:59,081
-does that mean? Yes. Like, yeah,
-dad hates computers. Cause she
+00:58:54,300 --> 00:58:55,692
+understand -- you know, she's
+like, "What? What does that 
+
+1119
+00:58:55,692 --> 00:58:58,000
+mean?" She's like, "Yeah. Dan
+hates computers." I'm like
 
 1120
-00:58:59,081 --> 00:59:01,961
-told me a story. Cause I was
-like, oh, yesterday I spent like
+00:58:58,000 --> 00:58:59,500
+[laughs] -- cuz she told me a
+story --
+
+1120
+00:58:59,500 --> 00:59:01,961
+cuz I was like, "Oh, yesterday
+I spent like
 
 1121
 00:59:01,961 --> 00:59:05,592
-three hours trying to get, I
-wasn't, I almost went over a
+three hours trying to get ..." I
+almost did it. I almost went
 
 1122
 00:59:05,592 --> 00:59:11,231
-PG 13 again, Ruby to work
-again on my computer. And it
+over a PG-13 again. Ruby to work
+again on my computer. And it was
 
 1123
 00:59:11,231 --> 00:59:14,112
-was really annoying and it like
-killed my whole day, you know,
+really annoying and it, like,
+killed my whole day, you know?
 
 1124
-00:59:14,411 --> 00:59:18,041
-anywhere else complained about
-it at home and was like, I hate
+00:59:14,411 --> 00:59:17,500
+Anyway, I was complaining about
+it at home, and was like, "Hey,
 
 1125
-00:59:18,041 --> 00:59:21,311
-computers. I don't like them.
-So, you know, well
+00:59:17,500 --> 00:59:19,000
+I hate computers-
 
 1126
-00:59:21,311 --> 00:59:22,961
-Kirk: the first time I learned
-Ruby, it was similar to that
+00:59:19,000 --> 00:59:19,500
+Kirk: The first time --
 
 1127
-00:59:23,021 --> 00:59:28,121
-Bekah situation. I was in
-internship. Well, we can't any,
+00:59:19,500 --> 00:59:21,000
+Dan: -I don't like them." So ...
+you know?
+
+1126
+00:59:21,000 --> 00:59:22,961
+Kirk: Well, the first time I
+learned Ruby, it was similar to
+
+1127
+00:59:23,021 --> 00:59:27,000
+Bekah's situation. I was in a
+internship. And they were like,
 
 1128
-00:59:28,181 --> 00:59:30,521
-can't get any developers up in
-this project. So you guys are
+00:59:27,000 --> 00:59:29,500
+"Well, we can't -- any -- you
+can't get any developers to help
+
+1128
+00:59:29,500 --> 00:59:31,300
+in this project. So you guys are
+gonna do it yourself." And we
 
 1129
-00:59:30,521 --> 00:59:32,922
-going to do it yourself and be
-like, okay, any of, you know,
+00:59:31,300 --> 00:59:34,000
+were like, "Okay." "Any of you
+know Ruby?" "No."
 
 1130
-00:59:32,922 --> 00:59:37,572
-Ruby? No, this was back in the
-time. They were like, here's the
+00:59:34,000 --> 00:59:37,572
+And then -- this was back in the
+time they were like, "Here's the
 
 1131
 00:59:37,572 --> 00:59:41,382
 instructions for how to install
-this on your machine? If you get
+this on your machine. If you get
 
 1132
 00:59:41,382 --> 00:59:45,822
-it wrong, we'll would probably
-break the machine. Good luck. So
+it wrong, you'll probably break
+the machine. Good luck." So,
 
 1133
-00:59:45,882 --> 00:59:52,302
-that's like, and it was super
-painful. And I didn't like, look
+00:59:45,882 --> 00:59:49,500
+that's like [chuckles] what's
+[inaudible] Ruby in, and it was
 
 1134
-00:59:52,362 --> 00:59:54,657
-at a line of Ruby again, what,
-10 years. So, you know,
+00:59:49,500 --> 00:59:52,362
+super painful. And I didn't,
+like, look
+
+1134
+00:59:52,362 --> 00:59:56,000
+at a line of Ruby again for like
+10 years. So ... you know?
 
 1135
-00:59:54,657 --> 00:59:56,952
-onboarding.
+00:59:56,000 --> 00:59:58,092
+Onboarding matters.
 
 1136
-00:59:58,092 --> 01:00:00,552
-Dan: Yeah, no, that's, it's
-like, it doesn't matter every
+00:59:58,092 --> 01:00:02,700
+Dan: Yeah. No. That's -- it's
+like, it doesn't matter. Every
 
 1137
-01:00:00,552 --> 01:00:03,012
-time I
+01:00:02,700 --> 01:00:03,500
+time I have to do something
 
 1138
-01:00:03,012 --> 01:00:04,316
-have to do something with her
-and I just do it so infrequently
-
-1139
-01:00:04,316 --> 01:00:05,620
-that
+01:00:03,500 --> 01:00:05,500
+with Ruby -- and I- I just do it
+so infrequently that it's, you
 
 1140
-01:00:05,621 --> 01:00:07,076
-it's, you know, that's why it's
-a problem for me, obviously, to
-
-1141
-01:00:07,076 --> 01:00:08,531
-be
+01:00:05,500 --> 01:00:08,000
+know, that's why it's a problem
+for me, obviously. But --
 
 1142
-01:00:08,532 --> 01:00:11,681
-Kirk: fair. I feel like I do
-Python stuff all the time and I
+01:00:08,000 --> 01:00:11,681
+Kirk: To be fair, I feel like I
+do Python stuff all the time
 
 1143
-01:00:11,681 --> 01:00:15,131
-still mess it up. Like getting
-it to work. I'm just, I just
+01:00:11,681 --> 01:00:15,500
+and- and I still mess it up,
+like, getting it to work on my
 
 1144
-01:00:15,131 --> 01:00:18,581
-want
+01:00:15,500 --> 01:00:18,581
+machine. I'm just -- I just want
 
 1145
-01:00:18,581 --> 01:00:22,751
-things to work. I just want to
+01:00:18,581 --> 01:00:23,000
+things to work. I just wanna
 click work and then they work.
 
 1146
-01:00:23,621 --> 01:00:26,382
-Yeah. Specifically the
+01:00:23,500 --> 01:00:24,000
+Dan: Yep.
+
+1146
+01:00:24,000 --> 01:00:26,382
+Kirk: Specifically the
 installation and running part.
 
 1147
+01:00:26,382 --> 01:00:26,500
+Bekah: Yes.
+
+1148
+01:00:26,700 --> 01:00:27,000
+Dan: Yep.
+
+1147
 01:00:27,311 --> 01:00:28,302
-Bekah: That's the worst
+Bekah: That's the worst.
 
 1148
 01:00:30,132 --> 01:00:33,731
-Kirk: I got into Loreal. I'm
-like, oh, I'm going to NPM
+Kirk: I got a tutorial, I'm
+like, "Oh, I'm gonna NPM,
 
 1149
 01:00:33,731 --> 01:00:38,981
-installed new thing. And bam did
-its thing. Do the thing run
+install, do your thing. NPM did
+its thing. Do the thing, run,
 
 1150
 01:00:39,371 --> 01:00:43,061
-didn't work. I Google the air,
+didn't work. I Google the err-
 you know, it's bad when you
 
 1151
-01:00:43,061 --> 01:00:46,452
-search for an air and it takes
-you to like, be official of like
+01:00:43,061 --> 01:00:45,500
+search for an error and it takes
+you to, like, the official
 
 1152
-01:00:46,512 --> 01:00:50,411
-issues on resolved page. Like,
-oh no,
+01:00:45,500 --> 01:00:51,000
+GitHub, like, issues unresolved
+page. Like, "Oh, no."
 
 1153
-01:00:52,211 --> 01:00:56,811
-Dan: I can't. I was deep into
-that yesterday. It doesn't
+01:00:51,000 --> 01:00:51,500
+Bekah: Damn.
 
 1154
-01:00:56,811 --> 01:00:59,902
-matter. Yeah. Anyway,
-computers are doing that. I hate
+01:00:52,000 --> 01:00:53,000
+Kirk: I can't escape [inaudible]
+--
+
+1153
+01:00:53,000 --> 01:00:56,500
+Dan: No, I was deep into that
+yesterday. A bunch of M1s that
+
+1154
+01:00:56,500 --> 01:00:57,000
+-- doesn't matter.
 
 1155
-01:00:59,902 --> 01:01:00,112
-them.
+01:00:57,000 --> 01:00:57,300
+Bekah: Yeah.
+
+1155
+01:00:57,300 --> 01:01:00,112
+Dan: Anyway, computers are
+annoying. And I hate them.
 
 1156
-01:01:00,592 --> 01:01:01,972
-Bekah: Also. I have to go
+01:01:00,592 --> 01:01:03,000
+Bekah: Also, I have to go. So
+[laughs] --
 
 1157
-01:01:04,371 --> 01:01:06,652
-Dan: to leave at three, not
-three 30.
+01:01:03,000 --> 01:01:06,652
+Dan: Ooh. You have to leave
+at 3? Not 3.30?
 
 1158
-01:01:08,422 --> 01:01:08,931
-Kirk: the week
+01:01:06,652 --> 01:01:08,931
+Kirk: I thought you were hanging
+out for like a week.
 
 1159
-01:01:11,362 --> 01:01:13,312
-Bekah: I have children, Bekah
-needs to go clean up the Creek
+01:01:09,500 --> 01:01:10,000
+Dan: Oh, man.
+
+1159
+01:01:11,362 --> 01:01:12,500
+Bekah: I have children.
 
 1160
-01:01:13,312 --> 01:01:15,262
-in
+01:01:12,500 --> 01:01:13,500
+Dan: Bekah needs to go.
 
 1161
-01:01:15,271 --> 01:01:15,411
-my.
+01:01:13,500 --> 01:01:16,500
+Bekah: I have to go clean up the
+creek in my neighbourhood.
 
 1162
-01:01:17,021 --> 01:01:19,181
+001:01:16,500 --> 01:01:18,500
 Dan: She needs to go clean up
-smokey
+the creek.
 
 1163
-01:01:19,181 --> 01:01:19,632
-Kirk: bear
+01:01:18,500 --> 01:01:20,000
+Kirk: Do you smokey the bear?
 
 1164
-01:01:20,472 --> 01:01:21,251
-Bekah: birthday
+01:01:20,472 --> 01:01:23,500
+Bekah: [Chuckles] For earth day.
+Week. Month.
 
 1165
-01:01:22,452 --> 01:01:30,702
-Dan: week. Kirk, I just want
-to say a happy Kirk Day to us
-
-1166
-01:01:30,702 --> 01:01:31,001
-all.
+01:01:25,000 --> 01:01:31,000
+Dan: Kirk, I just wanna say
+happy Kirk Day to us all.
 
 1167
-01:01:31,722 --> 01:01:35,952
-Bekah: We're glad to have you
-thank you for joining us and the
+01:01:31,722 --> 01:01:34,500
+Bekah: We're glad to have you as
+our one and only Kirk-
+
+1168
+01:01:33,500 --> 01:01:35,952
+Dan: Thank- thank you for
+joining us [chuckles].
 
 1168
 01:01:35,952 --> 01:01:36,641
-entire world.
+Bekah: -in the entire world.
 
 1169
-01:01:37,331 --> 01:01:44,172
-Kirk: I am. I'm happy to provide
-me as a catalyst for the pool.
+01:01:37,331 --> 01:01:37,700
+Kirk: I am-
 
 1170
-01:01:44,181 --> 01:01:48,282
-People here, Kirk Day is weird,
-but the people who like it are
+01:01:38,000 --> 01:01:38,500
+Dan: That too.
 
 1171
-01:01:48,282 --> 01:01:52,452
-great on this,
+01:01:38,500 --> 01:01:43,500
+Kirk: -I'm happy to provide me
+as a catalyst for
+
+1170
+01:01:43,500 --> 01:01:47,300
+the cool people here. Kirk Day
+is weird. But the people who
+
+1171
+01:01:47,300 --> 01:01:52,452
+like it are great [all laugh].
+We're kind of settled on this.
 
 1172
-01:01:54,822 --> 01:01:58,302
-Dan: we didn't plan any of this
-at all. So I appreciate you. If
+01:01:53,700 --> 01:01:56,300
+Dan: I'm glad you're around. We
+didn't plan any of this at all.
 
 1173
-01:01:58,302 --> 01:01:58,992
-you know, Dan
+01:01:56,300 --> 01:01:56,500
+So-
+
+1174
+01:01:56,500 --> 01:01:57,000
+Bekah: Mm-hmm.
+
+1175
+01:01:57,500 --> 01:01:58,700
+Dan: -I appreciate you, you
+know?
 
 1174
 01:01:58,992 --> 01:02:00,822
-Bekah: was like push to have an
-agenda. And I was like,
+Bekah: Dan was like, "We should
+have an agenda." And I was like
 
 1175
-01:02:02,862 --> 01:02:05,172
-Dan: we did get a lot of stuff
-done today. It was
+01:02:00,822 --> 01:02:02,862
+--
+
+1175
+01:02:02,862 --> 01:02:04,500
+Dan: We did get a lot of stuff
+done today.
 
 1176
-01:02:05,512 --> 01:02:09,282
-Bekah: a, but most importantly,
+01:02:04,500 --> 01:02:05,300
+Bekah: We got a ton of stuff
+done.
+
+1177
+01:02:04,800 --> 01:02:05,700
+Dan: It was a- it was a good --
+
+1176
+01:02:06,000 --> 01:02:09,282
+Bekah: But most importantly,
 we saw Kirk on Kirk Day and
 
 1177
 01:02:09,282 --> 01:02:10,481
-changed our profile pictures.
+changed our profile pictures-
 
 1178
-01:02:12,266 --> 01:02:16,786
-Kirk: Nick Taylor's profile
-picture is sideways. We noticed
+01:02:11,000 --> 01:02:11,300
+Dan: Indeed.
 
 1179
-01:02:16,786 --> 01:02:17,097
-that
+01:02:11,300 --> 01:02:12,000
+Bekah: -for Kirk.
+
+1178
+01:02:12,266 --> 01:02:15,500
+Kirk: Nick Taylor's profile
+picture is sideways. I don't --
+
+1179
+01:02:15,500 --> 01:02:20,000
+Bekah: [Bekah and dan laugh] We
+noticed that.
+
+1180
+01:02:20,000 --> 01:02:21,447
+Dan: That's awesome.
 
 1180
 01:02:21,447 --> 01:02:22,347
-Bekah: it all makes sense,
+Bekah: It all makes sense.
 
 1181
-01:02:23,047 --> 01:02:23,666
-Kirk: Don road.
+01:02:23,047 --> 01:02:26,000
+Kirk: The Kirk has gone rogue.
+[Bekah laughs] We are a legion.
 
 1182
-01:02:28,467 --> 01:02:29,876
-Bekah: Well, that seems like a
-great way to end.
+01:02:26,000 --> 01:02:29,500
+Bekah: [Laughs] Oh, my gosh.
+Well, that seems like a great
 
 1183
-01:02:30,927 --> 01:02:32,967
-Dan: That's a good one. Thank
-you everybody for hanging out
+01:02:29,500 --> 01:02:30,927
+way to end.
 
-1184
-01:02:32,967 --> 01:02:35,007
-and I'm
+1183
+01:02:30,927 --> 01:02:33,000
+Dan: Yep. That's a good one.
+Thank you everybody for hanging
 
 1185
-01:02:35,007 --> 01:02:37,947
-happy, corrected and see you
-Thursday.
+01:02:33,000 --> 01:02:36,000
+out, and happy Kirk Day, and --
 
 1186
-01:02:38,396 --> 01:02:49,376
-Kirk: No, don't do another one
-no more Kirk Days. Yeah, every
+01:02:36,000 --> 01:02:37,000
+Bekah: We'll see you all
+Thursday.
 
 1187
-01:02:49,376 --> 01:02:57,806
-single collective. It's fun. All
-right, bye.
+01:02:37,000 --> 01:02:37,700
+Dan: See you Thursday.
+
+1186
+01:02:38,396 --> 01:02:41,300
+Kirk: Don't- don't do another
+one. No more Kirk Days. From
+
+1187
+01:02:41,300 --> 01:02:41,500
+Kirk.
 
 1188
-01:03:01,206 --> 01:03:03,306
+01:02:42,000 --> 01:02:43,300
+Dan: See you next year at Kirk
+Day.
+
+1189
+01:02:43,300 --> 01:02:44,000
+Bekah: We do what we want.
+
+1190
+01:02:43,500 --> 01:02:45,000
+Kirk: [Inaudible] next year. The
+end.
+
+1191
+01:02:45,300 --> 01:02:46,000
+Bekah: You gonna fire us
+[laughs]?
+
+1192
+01:02:46,700 --> 01:02:50,000
+Kirk: Yeah. I'm gonna fire every
+single one of you.
+
+1193
+01:02:50,000 --> 01:02:51,000
+Bekah: You said you wouldn't
+fire me.
+
+1187
+01:02:52,500 --> 01:02:55,000
+Kirk: Yeah. But it's collective.
+It's fine.
+
+1188
+01:02:55,700 --> 01:02:56,000
+Dan: Alright.
+
+1189
+01:02:56,300 --> 01:02:57,500
+Kirk: Okay. Bye.
+
+1188
+01:03:01,206 --> 01:03:03,000
 Dan: Thank you for listening to
 this episode of the Virtual
 
 1189
-01:03:03,306 --> 01:03:07,052
+01:03:03,000 --> 01:03:07,052
 Coffee Podcast. This episode was
 produced by Dan Ott and Bekah
 
 1190
-01:03:07,052 --> 01:03:08,441
+01:03:07,052 --> 01:03:09,500
 Hawrot Weigel. If you have
 questions or comments, you can
 
-1191
-01:03:08,441 --> 01:03:09,830
-hit
-
 1192
-01:03:09,831 --> 01:03:12,842
-us up on Twitter at
+01:03:09,500 --> 01:03:12,842
+hit us up on Twitter at
 VirtualCoffeeIO, or email us at
 
 1193
-01:03:12,842 --> 01:03:14,576
+01:03:12,842 --> 01:03:16,000
 podcast@virtualcoffee.io. You
 can find the show notes, sign up
 
-1194
-01:03:14,576 --> 01:03:16,310
-for
-
 1195
-01:03:16,311 --> 01:03:18,351
-the newsletter, check out any of
-our other resources on our
+01:03:16,000 --> 01:03:18,351
+for the newsletter, check out
+any of our other resources on our
 
 1196
 01:03:18,351 --> 01:03:21,742
@@ -6404,14 +7965,10 @@ at virtualcoffee.io/sponsorship.
 Please subscribe to our podcast
 
 1199
-01:03:28,882 --> 01:03:30,487
+01:03:28,882 --> 01:03:31,700
 and be sure to leave us a
 review. Thanks for listening,
 
 1200
-01:03:30,487 --> 01:03:32,092
-and we'll
-
-1201
-01:03:32,092 --> 01:03:32,931
-see you next week!
+01:03:31,700 --> 01:03:33,092
+and we'll see you next week!

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -10,7 +10,7 @@ of
 3
 00:00:09,560 --> 00:00:15,528
 the Virtual Coffee Podcast. I'm
-Dan and this is a podcast that
+Dan. And this is a podcast that
 
 4
 00:00:15,528 --> 00:00:18,559
@@ -24,302 +24,410 @@ developers at all stages of
 
 6
 00:00:20,028 --> 00:00:21,497
-their
+their coding
 
 7
 00:00:21,498 --> 00:00:25,368
-coding journey. And they're here
-on this podcast usually sharing
+journey. And they're here on
+this podcast, usually, sharing
 
 8
 00:00:25,368 --> 00:00:28,189
 their stories and what they've
-learned uh today we had a little
+learned. Today, we had a little
 
 9
 00:00:28,189 --> 00:00:31,428
-bit of a different time, Bekah
-actually it came up to Cleveland
+bit of a different time. Bekah
+actually came up to Cleveland
 
 10
 00:00:31,489 --> 00:00:35,959
-uh where i work And uh we
+— where I work. And we
 actually met in person for the
 
 11
 00:00:35,959 --> 00:00:38,929
 first time ever after knowing
-each other for over three years
+each other for over three years.
 
 12
 00:00:39,259 --> 00:00:42,859
-and it was fun and today is also
-a Kirk Day which you will hear
+And it was fun. And today is
+also a Kirk Day which you will
 
 13
 00:00:42,859 --> 00:00:47,058
-about uh A little bit later in
-the episode and uh also Kirk.
+hear about a little bit later in
+the episode. And also, Kirk
 
 14
 00:00:47,448 --> 00:00:50,959
-Joins us as well and it was
-really fun and it was a fun
+joined us as well, and it was
+really fun. And it was a fun
 
 15
 00:00:50,959 --> 00:00:52,008
-little thing we streamed it live
-we had some people sharing in
+little thing. We streamed it
+live, we had some people sharing
 
 16
 00:00:52,008 --> 00:00:53,057
-the
+in the
 
 17
 00:00:53,088 --> 00:00:54,618
-comments And we thought we would
-share it on the podcast stream
+comments, and we thought we
+would share it on the podcast
 
 18
 00:00:54,618 --> 00:00:56,148
-as
+stream as
 
 19
 00:00:56,149 --> 00:01:00,649
-well so enjoy and uh next week
+well. So enjoy, and next week
 we will get back to our regular
 
 20
-00:01:00,649 --> 00:01:14,766
-schedule Hey, we were muted the
-whole time. Why did you do it? I
+00:01:00,649 --> 00:01:10,000
+schedule. Hey, we were muted the
+whole time [Bekah laughs].
 
 21
-00:01:14,766 --> 00:01:16,316
-was just thinking in my head.
-Oh, I hope the sound sounds
+00:01:10,000 --> 00:01:12,000
+Bekah, why did you do it?
+
+22
+00:01:13,000 --> 00:01:14,000
+Bekah Hawrot Weigel: I was on my
+phone [laughs].
+
+21
+00:01:14,300 --> 00:01:16,316
+Dan: I was just thinking in my
+head, "Oh, I hope the sound
 
 22
 00:01:16,316 --> 00:01:17,866
-good. It
+sounds good." And then, I- I
 
 23
 00:01:17,867 --> 00:01:20,537
-was like, I looked at the mute
-thing and
+was like, "Huh?" I looked at the
+mute thing and --
 
 24
-00:01:21,496 --> 00:01:23,401
-Bekah Hawrot Weigel: just so
-everybody knows, I just did the
+00:01:21,496 --> 00:01:23,000
+Bekah: Just so everybody knows,
+I just did-
 
 25
-00:01:23,401 --> 00:01:25,306
-most amazing intro
+00:01:22,500 --> 00:01:23,200
+Dan: You did a great job.
+
+25
+00:01:23,200 --> 00:01:23,700
+Bekah: -the most amazing-
 
 26
-00:01:25,367 --> 00:01:26,266
-that I've ever done.
+00:01:24,000 --> 00:01:24,700
+Dan: It was awesome.
 
 27
-00:01:27,076 --> 00:01:28,367
-Dan: It's good.
+00:01:25,000 --> 00:01:26,000
+Bekah: -intro that I've ever
+done.
 
 28
-00:01:30,257 --> 00:01:34,156
+00:01:26,300 --> 00:01:26,500
+Dan: Yep.
+
+29
+00:01:27,000 --> 00:01:28,000
+Bekah: It's- it's suck
+[chuckles].
+
+27
+00:01:27,700 --> 00:01:29,300
+Dan: It's really good. Yep.
+
+28
+00:01:30,257 --> 00:01:32,000
 Bekah: So here's my not so great
-intro. We are coming from
+intro.
+
+29
+00:01:32,000 --> 00:01:32,300
+Dan: We do.
+
+30
+00:01:32,500 --> 00:01:34,156
+Bekah: We are coming here, live
 
 29
 00:01:34,156 --> 00:01:37,816
-Lakewood, Ohio. We are
+from Lakewood, Ohio. We are
 celebrating national Kirk day or
 
 30
 00:01:37,816 --> 00:01:40,757
-international Kirk day. As we
-more fondly, know it at Virtual
+international Kirk day as we
+more fondly know it at Virtual
 
 31
 00:01:40,757 --> 00:01:41,236
-Coffee,
+Coffee.
 
 32
 00:01:41,596 --> 00:01:42,337
-Dan: inner galactic
+Dan: Intergalactic Kirk day?
 
 33
 00:01:43,996 --> 00:01:47,147
-Bekah: galactic, inter I was
-gonna say disciplinary. That is
+Bekah: Intra galactic? Inter- I
+was gonna say disciplinary. That
 
 34
-00:01:47,147 --> 00:01:50,057
-not the right word dimensional
-interdimensional Kirk day,
+00:01:47,147 --> 00:01:49,500
+is not the right word.
+Dimensional -- interdimensional
+
+35
+00:01:49,500 --> 00:01:50,057
+Kirk day.
+
+36
+00:01:50,057 --> 00:01:50,656
+Dan: Yeah.
 
 35
 00:01:50,656 --> 00:01:53,027
-because it is preserved
-everywhere because perk is
+Bekah: Because it is preserved
+everywhere, because perk is
 
 36
 00:01:53,027 --> 00:01:56,266
-awesome and amazing. And we like
+awesome and amazing, and we like
 to celebrate Kirk as much as we
 
 37
-00:01:56,266 --> 00:02:01,186
-can. Dan, would you like to
+00:01:56,266 --> 00:01:57,000
+can.
+
+38
+00:01:57,300 --> 00:01:58,000
+Dan: Agreed.
+
+00:01:58,500 --> 00:02:01,186
+Bekah: Dan, would you like to
 introduce what international
 
 38
 00:02:01,277 --> 00:02:03,917
 dimensional disciplinary Kirk
-date is?
+day is?
 
 39
-00:02:05,027 --> 00:02:10,727
-Dan: So was it just a year
-ago or a year ago today? Yes,
+00:02:05,027 --> 00:02:08,000
+Dan: So, was it just a year
+ago-
 
 40
-00:02:10,757 --> 00:02:16,481
-Kirk, had a tweet. Where he
-showed me that I should read
+00:02:08,000 --> 00:02:09,500
+Bekah: It was a year ago, today.
 
 41
-00:02:16,481 --> 00:02:20,501
-that. I feel like I should have
-read the, the right text. This
+00:02:08,500 --> 00:02:10,727
+Dan: two years ago? Today? Yes,
+
+40
+00:02:10,757 --> 00:02:16,500
+Kirk had a tweet where he showed
+-- how should I read the --
+
+41
+00:02:16,500 --> 00:02:17,800
+Bekah: You should. And put in
+the announcement.
 
 42
-00:02:20,501 --> 00:02:24,521
-is
+00:02:17,800 --> 00:02:20,501
+Dan: I feel like I should have
+read the- the right text.
+
+00:02:20,501 --> 00:02:21,300
+Bekah: Post it in the chat too. 
+
+42
+00:02:21,300 --> 00:02:24,521
+Dan: The- the- the -- this is
+it, right?
 
 43
-00:02:24,521 --> 00:02:30,372
-it, right? Yeah. So Kirk tweeted
-today, we achieved the dream. My
+00:02:24,521 --> 00:02:24,700
+Bekah: Mm-hmm.
+
+44
+00:02:24,700 --> 00:02:29,500
+Dan: Yeah. So, Kirk tweeted,
+"Today we have achieved the
+
+45
+00:02:29,500 --> 00:02:30,412
+dream. My -- I
 
 44
 00:02:30,412 --> 00:02:32,801
 made a function called Missy
-Elliott. That takes data
+Elliott that takes data
 
 45
 00:02:32,981 --> 00:02:37,572
 structure, flips it and reverses
-it. I have ascended. And then,
+it. I have ascended." And then,
 
 46
-00:02:37,662 --> 00:02:43,002
+00:02:37,662 --> 00:02:42,000
 very shortly after that,
-Missy Elliott responded, replied
+Missy Elliott responded
 
 47
-00:02:43,002 --> 00:02:46,241
-on Twitter, actual Missy
-Elliott, not, not a fake Missy
+00:02:42,000 --> 00:02:45,700
+[chuckles], replied on Twitter.
+Actual Missy Elliott. Not- not a
 
 48
-00:02:46,241 --> 00:02:50,592
-Elliott and, and said something
-like, yeah, she said, wow, I'm
+00:02:45,700 --> 00:02:46,000
+fake Missy Elliott.
+
+49
+00:02:46,000 --> 00:02:47,000
+Bekah: The Missy Elliott. That's
+--
+
+50
+00:02:47,500 --> 00:02:50,592
+Dan: And- and said something
+like, yeah, she said, "Wow, I'm
 
 49
 00:02:50,592 --> 00:02:53,366
-humbly I'm. So humbly grateful,
-much love to y'all. And,
+humbly -- I'm so humbly
+grateful. Much love to y'all."
 
 50
 00:02:53,366 --> 00:02:56,140
-that
+And that
 
 51
 00:02:56,141 --> 00:02:59,981
 was the beginning of a legend.
-It was, it was really, really
+It was- it was really, really
 
 52
-00:02:59,981 --> 00:03:03,822
-awesome. And, everybody saw
-it and perks, you know, Twitter.
+00:02:59,981 --> 00:03:03,700
+awesome [laughs]. And everybody
+saw it, and perks, you know,
 
 53
-00:03:04,542 --> 00:03:08,442
-Let's see what the, It,
-it Kirk's sweet, got a one
+00:03:03,700 --> 00:03:03,822
+Twitter ...
+
+53
+00:03:04,542 --> 00:03:10,000
+well, let's see what the -- it-
+it- it Kirk's tweet got a one
 
 54
-00:03:08,442 --> 00:03:12,342
-13,300
+00:03:10,300 --> 00:03:13,700
+-- 13,3 thousand retweets
+[laughs] and a hundred --
 
 55
-00:03:12,342 --> 00:03:18,282
-retweets. And it's really
+00:03:13,700 --> 00:03:15,700
+Bekah: A hundred and 70
+[chuckles] -- 70 thousand like.
+
+56
+00:03:15,700 --> 00:03:18,282
+Dan: Yeah. And it's really
 good stuff.
 
 56
 00:03:18,882 --> 00:03:21,117
-Bekah: Yeah. But not only that,
+Bekah: It -- but not only that,
 not only was it just YouTube,
 
 57
-00:03:21,117 --> 00:03:23,352
-but
+00:03:21,117 --> 00:03:26,300
+but it expanded. So this was not
+a one day event. It was-
 
 58
-00:03:23,352 --> 00:03:27,521
-it expanded. So this was not a
-one day event. It was, it was on
+00:03:26,300 --> 00:03:26,700
+Dan: Yeah.
 
 59
-00:03:27,822 --> 00:03:32,891
-Twitter. It was on LinkedIn. It
-was on Reddit. Everybody loves
+00:03:26,700 --> 00:03:28,000
+Bekah: -it was on Twitter,
+
+59
+00:03:28,000 --> 00:03:33,000
+it was on LinkedIn, it was on
+Reddit. Everybody loves Kirk.
 
 60
-00:03:32,891 --> 00:03:37,151
-Dan: Kirk. Yes. And we all are
+00:03:33,000 --> 00:03:37,151
+Dan: Yes. And we all are --
 already loved Kirk. And this is
 
 61
 00:03:37,151 --> 00:03:40,122
-just a sort of celebration of,
-of, the rest of the world.
+just a sort of celebration of-
+of the rest of the world,
 
 62
-00:03:40,181 --> 00:03:41,801
-Right. Becoming aware
+00:03:40,181 --> 00:03:40,500
+right?
 
 63
-00:03:42,312 --> 00:03:45,312
-Bekah: of, of the Kirk. So maybe
-we should tell our Kirk origin
+00:03:40,500 --> 00:03:40,700
+Bekah: Yeah.
 
 64
-00:03:45,312 --> 00:03:45,822
-story.
+00:03:40,700 --> 00:03:43,000
+Dan: Be-becoming aware of- of
+the Kirk.
+
+63
+00:03:43,000 --> 00:03:45,822
+Bekah: So maybe we should tell
+our Kirk's origin story.
 
 65
-00:03:47,771 --> 00:03:49,691
+00:03:47,771 --> 00:03:51,000
 Dan: I think that's a great
-idea. Do you want me to go
+idea [laughs]. Do you want me to
 
 66
-00:03:49,691 --> 00:03:51,611
+00:03:51,000 --> 00:03:52,000
+go first? Do you want to go
 first?
 
 67
-00:03:51,611 --> 00:03:55,122
-Do you want to go first? You go
-first. I mean, I don't have a
+00:03:52,700 --> 00:03:53,300
+Bekah: You go first.
+
+68
+00:03:53,300 --> 00:03:55,122
+Dan: Alright. I don't -- I mean,
+I, like -- I don't have a
 
 68
 00:03:55,122 --> 00:03:56,967
-specific, I don't remember the
-like moment right. Of, of
+specific -- I don't remember
+the, like, moment right? Of- of
 
 69
 00:03:56,967 --> 00:03:58,812
@@ -327,51 +435,51 @@ meeting
 
 70
 00:03:58,812 --> 00:04:03,056
-her. Cause that was back in the
-time of. Virtual Coffee being,
+Kirk. Cuz that was back in the
+time of Virtual Coffee being --
 
 71
-00:04:03,146 --> 00:04:08,097
-a little it's a little
-smaller, you know? And so we had
+00:04:04,000 --> 00:04:04,500
+Bekah: A tiny baby.
+
+71
+00:04:04,500 --> 00:04:08,097
+Dan: Yes. Very s- a little
+smaller, you know? And so, we
 
 72
-00:04:08,097 --> 00:04:12,161
-slack, we had, the coffees
-obviously. But, and I'm not
-
-73
-00:04:12,161 --> 00:04:16,225
-a
+00:04:08,097 --> 00:04:15,700
+had Slack, we had the coffees,
+obviously. But -- and I'm not
 
 74
-00:04:16,226 --> 00:04:18,506
-person who, I don't know, I
-don't know a lot of people, I
+00:04:15,700 --> 00:04:20,000
+a person who ... I don't know. I
+don't know a lot of people
 
 75
-00:04:18,506 --> 00:04:20,786
-don't
+00:04:20,000 --> 00:04:20,786
+[laughs]. I don't really
 
 76
 00:04:20,786 --> 00:04:23,307
-really like people don't stick
-in my brain until, until we like
+-- like, people don't stick in
+my brain until- until we, like,
 
 77
 00:04:23,307 --> 00:04:27,357
 interact. You know what I mean?
-And so my thing with Kirk was,
+And so, my thing with Kirk was-
 
 78
 00:04:27,387 --> 00:04:29,786
-was really the heck Tober
-festivals really like leading up
+was really the Hacktoberfest.
+Was really, like, leading up
 
 79
 00:04:29,786 --> 00:04:32,431
-to October Fest that year. So it
-was two years ago. And,
+to Hacktoberfest that year. So
+it was two years ago. And ...
 
 80
 00:04:32,431 --> 00:04:35,076
@@ -383,110 +491,136 @@ and I, you know, we worked
 together and I had known Sarah
 
 82
-00:04:38,997 --> 00:04:41,014
-because she was. You know, like
-she was already like helping
-
-83
-00:04:41,014 --> 00:04:43,031
-them
+00:04:38,997 --> 00:04:42,700
+because she was, you know, like,
+she was already, like, helping
 
 84
-00:04:43,031 --> 00:04:47,201
-with virtual profit and all that
-stuff. And, I could just
+00:04:42,700 --> 00:04:47,201
+with Virtual Coffee and all that
+stuff. And I could just
 
 85
-00:04:47,201 --> 00:04:49,062
+00:04:47,201 --> 00:04:49,700
 kinda wrote me in for
-Hacktoberfest
+Hacktoberfest to, like, help.
 
 86
-00:04:49,182 --> 00:04:50,816
-Bekah: to like help. Okay. And
-to be fair, you were like, if
+00:04:50,000 --> 00:04:50,300
+Bekah: You -- okay.
 
 87
-00:04:50,816 --> 00:04:52,450
-you
+00:04:50,500 --> 00:04:51,000
+Dan: And I was excited.
+
+88
+00:04:50,700 --> 00:04:52,450
+Bekah:  To be fair, you were
+like, "If you
 
 88
 00:04:52,451 --> 00:04:54,641
 need help with anything, let me
-know. I may have said that. So
+know."
 
 89
-00:04:54,641 --> 00:04:56,831
-if
+00:04:54,641 --> 00:04:56,000
+Dan: I may have said that.
 
 90
-00:04:56,831 --> 00:04:57,851
-you offer to help,
+00:04:56,000 --> 00:04:59,000
+Bekah: So, if you offer to help,
+you will [chuckles].
 
 91
-00:04:58,661 --> 00:05:00,956
-Dan: you will. It's true.
-Yes, most people find that
-
-92
-00:05:00,956 --> 00:05:03,251
-out
+00:05:00,000 --> 00:05:02,500
+Dan:  It's true. Yes, most
+people find that about -- out
 
 93
-00:05:03,252 --> 00:05:05,712
-about eventually. But yeah,
-so Kirk was there too. Right.
+00:05:02,500 --> 00:05:07,700
+about that eventually. But,
+yeah. So, Kirk was there too,
 
 94
-00:05:05,712 --> 00:05:08,172
-And
+00:05:07,700 --> 00:05:08,700
+right? And I have, like --
 
 95
-00:05:08,172 --> 00:05:10,541
-I have, like, I like, you know,
+00:05:08,700 --> 00:05:10,541
+I, like -- you- you know,
 I'd heard his name or whatever.
 
 96
-00:05:10,541 --> 00:05:16,091
-I, you know, we had been, he was
-still TK that's right. He was
+00:05:10,541 --> 00:05:11,700
+I, you know, we had been --
+
+97
+00:05:11,700 --> 00:05:12,700
+Bekah: But he wasn't Kirk at
+that point.
+
+98
+00:05:13,000 --> 00:05:14,000
+Dan: He was still TK.
+
+99
+00:05:14,000 --> 00:05:14,800
+Bekah: He was still TK.
+
+100
+00:05:15,000 --> 00:05:16,091
+Dan: That's right. He was
 
 97
 00:05:16,091 --> 00:05:21,132
 just the mysterious TK, which
-made me, you know, what to know
+made me, you know, want to know
 
 98
 00:05:21,132 --> 00:05:24,132
-him more, you know, because
+him more, you know? Because,
 anyway, that has a mysterious
 
 99
-00:05:24,132 --> 00:05:25,161
-Bekah: name, you know?
+00:05:24,132 --> 00:05:25,000
+name, you know? You need to-
+
+100
+00:05:24,300 --> 00:05:25,500
+Bekah: Mm-hmm. Yeah. You need to
+know-
+
+101
+00:05:25,500 --> 00:05:26,000
+Dan: -know more --
+
+102
+00:05:25,700 --> 00:05:27,000
+Bekah: -more of the story.
 
 100
 00:05:27,672 --> 00:05:29,831
-Dan: And, yeah. And then
-that, so that it was like that
+Dan: And, yeah. And then that
+-- so that -- it was like that
 
 101
 00:05:29,831 --> 00:05:32,569
-September leading up to,
-That October, it was a lot of
+September leading up to
+that October, it was a lot of
 
 102
 00:05:32,569 --> 00:05:35,307
-Kirk and
+Kirk and I were
 
 103
 00:05:35,307 --> 00:05:37,976
-I were, I mean, I was working on
+-- I mean, I was working on
 the site and that's when the
 
 104
 00:05:37,976 --> 00:05:39,206
-first like this, the current
+first like this -- the current
 version of the site happened,
 
 105
@@ -495,8 +629,8 @@ you
 
 106
 00:05:40,437 --> 00:05:41,772
-know, we made the leap like
-that. We should probably have a
+know? We made the leap with like
+-- that which has brought us the
 
 107
 00:05:41,772 --> 00:05:43,107
@@ -505,73 +639,74 @@ site
 108
 00:05:43,107 --> 00:05:45,357
 for Virtual Coffee where we're
-doing all that stuff. And so I
+doing all that stuff. And so, I
 
 109
-00:05:45,357 --> 00:05:50,607
+00:05:45,357 --> 00:05:49,700
 would be up in the middle of the
-night. And Kirk was usually
+night [chuckles]. And Kirk was
 
 110
-00:05:50,607 --> 00:05:52,242
-there too. And we would like
-talk and, you know, throw ideas
+00:05:49,700 --> 00:05:53,000
+usual- usually there too. And we
+would like talk, and, you know,
 
 111
-00:05:52,242 --> 00:05:53,877
-back
+00:05:53,000 --> 00:05:53,700
+throw ideas back
 
 112
-00:05:53,877 --> 00:05:55,331
-and forth and think about
+00:05:53,700 --> 00:05:56,700
+and forth, and think about
 things. And then he was doing a
 
 113
-00:05:55,331 --> 00:05:56,785
-lot of
+00:05:56,700 --> 00:06:00,000
+lot of the work on the ... I
+dunno. More --
 
 114
-00:05:56,786 --> 00:06:02,607
-the work on the, I dunno, more
-social aspect of it, the
+00:06:00,000 --> 00:06:00,700
+Bekah: Documentation part.
 
 115
-00:06:02,607 --> 00:06:03,552
-documentation, you know,
-thinking about how like people
+00:06:01,000 --> 00:06:03,000
+Dan: Yeah, social aspect of it,
+the documentation, you know,
 
-116
-00:06:03,552 --> 00:06:04,497
+115
+00:06:03,000 --> 00:06:04,497
+thinking about how, like, people
 are going
 
 117
 00:06:04,497 --> 00:06:07,976
-to interact with Virtual Coffee
-and like how, we need
+to interact with Virtual Coffee,
+and like how we need
 
 118
 00:06:08,307 --> 00:06:11,156
-resources for maintainers and
-what those could look like and
+resources for maintainers, and
+what those could look like, and
 
 119
 00:06:11,156 --> 00:06:12,896
 things like that. And so I
-gained a lot of like both, it
+gained a lot of like -- both, it
 
 120
 00:06:12,896 --> 00:06:14,636
-was like
+was like fun to
 
 121
 00:06:14,637 --> 00:06:16,947
-fun to hang out with them. And
-again, a lot of like respect for
+hang out with them. And again,
+a lot of, like, respect for
 
 122
 00:06:16,947 --> 00:06:21,086
 him, you know, at the same time.
-So, so yeah, and then after
+So- so, yeah. And then after
 
 123
 00:06:21,086 --> 00:06:23,906
@@ -579,54 +714,103 @@ that, it was just like, we're
 just talking every day and had
 
 124
-00:06:24,237 --> 00:06:28,526
-been doing that for. The last
-million years, I don't, it feels
+00:06:24,237 --> 00:06:25,000
+been doing that for-
 
 125
-00:06:28,526 --> 00:06:31,226
-like I don't, I don't know all
-the dimensions, you know, in, in
+00:06:26,000 --> 00:06:26,300
+Bekah: Ever?
 
 126
-00:06:31,226 --> 00:06:34,916
-multiple dimensions, I'd say,
-if we're gonna use MCU
+00:06:26,300 --> 00:06:28,526
+Dan: -the last ... million
+years? I don't -- it feels
+
+125
+00:06:28,526 --> 00:06:29,500
+like -- I don't- I don't know.
+
+126
+00:06:29,500 --> 00:06:30,500
+Bekah: In all dimension?
 
 127
-00:06:35,807 --> 00:06:37,446
-terminology though, Kirk would
-be like an XSP, right. So
+00:06:30,500 --> 00:06:31,226
+Dan: You know, in- in
+
+126
+00:06:31,226 --> 00:06:35,000
+multiple dimensions. I'd say,
+if we're gonna use MCU, you
+
+127
+00:06:35,000 --> 00:06:38,500
+know, terminology though, Kirk
+would be like a Nexus being,
 
 128
-00:06:37,446 --> 00:06:39,085
-there's
+00:06:38,500 --> 00:06:41,700
+right? So, there's only like,
+one Kirk-
 
 129
-00:06:39,086 --> 00:06:43,091
-only like one Kirk yes. Across
-the dimensions. Yes. He's Arco
+00:06:42,000 --> 00:06:42,300
+Bekah: Yes.
 
 130
-00:06:43,091 --> 00:06:47,096
-is
+00:06:42,500 --> 00:06:43,500
+Dan: -across the dimensions.
+This --
 
 131
-00:06:47,096 --> 00:06:47,757
-prime Kirkland.
+00:06:43,500 --> 00:06:44,000
+Bekah: Yes.
+
+130
+00:06:44,500 --> 00:06:46,500
+Dan: He's -- our Kirk [??]-
+
+131
+00:06:46,500 --> 00:06:46,700
+Bekah: Our Kirk [??].
+
+131
+00:06:46,700 --> 00:06:47,500
+Dan: -our Kirk [??] is prime
+Kirk in there --
 
 132
-00:06:48,226 --> 00:06:51,716
-Bekah: Yeah. That's what I mean.
-Yeah, for sure. He's the right
+00:06:47,300 --> 00:06:47,700
+Bekah: All the Kirks.
 
 133
-00:06:51,716 --> 00:06:52,076
-Kirk.
+00:06:48,000 --> 00:06:48,700
+Dan: Yeah, yeah, yeah.
+
+134
+00:06:49,000 --> 00:06:49,300
+Bekah: Yeah.
+
+132
+00:06:49,300 --> 00:06:50,000
+Dan: That's what I mean.
+Yeah.
+
+133
+00:06:50,000 --> 00:06:50,300
+Bekah: For sure.
+
+134
+00:06:50,300 --. 00:06:50,500
+Dan: Yeah.
+
+135
+00:06:51,000 --> 00:06:52,076
+Bekah: He's the right Kirk.
 
 134
 00:06:53,547 --> 00:06:54,146
-Dan: Exactly.
+Dan: Exactly [laughs].
 
 135
 00:06:56,427 --> 00:06:58,992
@@ -639,125 +823,138 @@ it
 
 137
 00:07:01,557 --> 00:07:05,637
-exactly, but I have known Curt
+exactly, but I have known Kirk
 longer than most of the people
 
 138
-00:07:05,637 --> 00:07:07,211
+00:07:05,637 --> 00:07:08,500
 I've known at Virtual Coffee.
 But back when I knew Kirk, he
 
-139
-00:07:07,211 --> 00:07:08,785
-was
-
 140
-00:07:08,786 --> 00:07:15,146
-like a DVO Python image or a
-snake. I caught, he was not, I
+00:07:08,500 --> 00:07:13,500
+was like a -- maybe a python
+image or a snake icon?
 
 141
-00:07:15,146 --> 00:07:16,991
-didn't know his face. And then
-he started coming to Virtual
+00:07:13,500 --> 00:07:14,000
+Dan: Oh, yeah, yeah.
+
+142
+00:07:14,500 --> 00:07:14,700
+Bekah: He was not-
+
+143
+00:07:14,700 --> 00:07:15,000
+Dan: Yeah. He --
+
+141
+00:07:15,000 --> 00:07:16,991
+Bekah: -I didn't know his face.
+And then he started coming to
 
 142
 00:07:16,991 --> 00:07:18,836
-Coffee
+Virtual Coffee,
 
 143
 00:07:19,286 --> 00:07:25,646
-and. I am really, like
+and I am really ... like,
 nervous when I meet new people.
 
 144
-00:07:26,036 --> 00:07:28,376
-And then I was like, I think
-this person knows me and I had
+00:07:26,036 --> 00:07:30,000
+And then, I was like, "I think
+this person knows me?" And I had
 
 145
-00:07:28,376 --> 00:07:30,716
-to try
+00:07:30,000 --> 00:07:30,716
+to try and figure
 
 146
 00:07:30,716 --> 00:07:33,206
-and figure it out. And he would
-sit in this office, like with a
+it out [laughs]. And he would
+sit in this office, like, with a
 
 147
 00:07:33,206 --> 00:07:38,966
-slag behind him and everybody's
+flag behind him, and everybody's
 wearing masks back then when you
 
 148
 00:07:38,966 --> 00:07:43,317
-were on zoom. And so I'm like,
-who is this person that is
+were on Zoom. And so I'm like,
+"Who is this person that is
 
 149
 00:07:43,317 --> 00:07:47,127
 coming? I'm very nervous about
-them. And then Kirk kept
+them." And then Kirk kept
 
 150
-00:07:47,127 --> 00:07:50,786
-showing up. I'm like, okay, this
-is like, this, this person might
+00:07:47,127 --> 00:07:50,000
+showing up. I'm like, "Okay.
+This is like, this- this person
 
 151
-00:07:50,786 --> 00:07:52,676
-be my friend. I think maybe
-we're moving into friendship
+00:07:50,000 --> 00:07:53,500
+might be my friend. I think
+maybe we're moving into
 
 152
-00:07:52,676 --> 00:07:54,566
-right now.
+00:07:53,500 --> 00:07:54,566
+friendship right now.
 
 153
 00:07:54,987 --> 00:07:57,131
-And then when we were moving
-into heck Tober vest, I was
+And then, when we were moving
+into Hacktoberfest, I was
 
 154
 00:07:57,131 --> 00:07:59,275
-like, Hmm,
+like, "Hmm."
 
 155
-00:08:01,286 --> 00:08:03,146
+00:08:01,286 --> 00:08:04,700
 I don't know who suggested it.
-Somehow. Kirk ended up on the
-
-156
-00:08:03,146 --> 00:08:05,006
-HEC
+Somehow, Kirk ended up on the
 
 157
-00:08:05,007 --> 00:08:10,766
-Tober Fest team and it was,
-me Dan, Sarah, Brian, and Kirk.
+00:08:04,700 --> 00:08:10,766
+Hacktoberfest team. And it was
+me, Dan, Sarah, Brian, and Kirk.
 
 158
-00:08:11,276 --> 00:08:13,406
-And I feel like me, Sarah, Dan
-and Ryan were like talk dot,
+00:08:11,276 --> 00:08:15,000
+And I feel like me, Sarah, Dan,
+and Brian were like,
 
 159
-00:08:13,406 --> 00:08:15,536
-dot,
+00:08:15,000 --> 00:08:16,500
+"[in fast speed] Talk, talk,
+talk."
 
 160
-00:08:15,536 --> 00:08:20,187
-dot, dot, dot, dot. Why don't we
-think about this for a second,
+00:08:16,500 --> 00:08:20,187
+And Kirk was like, "Why don't we
+think about this for a second?"
 
 161
-00:08:21,987 --> 00:08:29,156
-like you used to be probably
-shed. So Kirk was, always
+00:08:21,987 --> 00:08:26,000
+[All laugh] Like, "Yes, we
+shall -- probably should."
+
+162
+00:08:26,000 --. 00:08:27,000
+Dan: Notorious [??].
+
+163
+00:08:27,500 --> 00:08:29,156
+Bekah: So, Kirk was always
 
 162
 00:08:29,156 --> 00:08:34,466
-doing a great job of, roping
+doing a great job of roping
 us all back to having productive
 
 163
@@ -771,46 +968,42 @@ we were
 
 165
 00:08:37,797 --> 00:08:39,566
-really excited about doing and
+really excited about doing, and
 making sure that they happen.
 
-166
-00:08:39,566 --> 00:08:41,335
-And
-
 167
-00:08:41,726 --> 00:08:44,106
-like, for me, I had not really.
-I ever heard about
+00:08:41,726 --> 00:08:45,500
+And -- like, for me, I like --
+had not really ever I've heard
 
 168
-00:08:44,106 --> 00:08:46,486
-documentation.
+00:08:45,500 --> 00:08:46,486
+about documentation,
 
 169
 00:08:46,486 --> 00:08:49,697
-Like you talk about
-documentation, put like, what is
+like, talk about documentation
+[laughs]. Put like, "What is
 
 170
 00:08:49,697 --> 00:08:52,456
-that thing? And then like, Kirk
-was like, breaking it down. This
+that thing?" And then, like,
+Kirk was like, breaking it down.
 
 171
 00:08:52,456 --> 00:08:54,826
-is why documentation is
+This is why documentation is
 important. And then, you know,
 
 172
 00:08:54,826 --> 00:08:58,037
 Kirk has a teaching background
-too. And so it was like, okay,
+too. And so it was like, "Okay,
 
 173
 00:08:58,037 --> 00:09:00,256
 this is starting to click a
-little bit more for me. And to
+little bit more for me." And to,
 
 174
 00:09:00,256 --> 00:09:04,366
@@ -819,31 +1012,38 @@ people through the documentation
 
 175
 00:09:04,636 --> 00:09:08,836
-became, something that was
+became something that was
 like a change in my life, you
 
 176
-00:09:08,836 --> 00:09:12,541
-know, like no big deal, but
-that's all. So all right,
+00:09:08,836 --> 00:09:11,700
+know, I will make no big deal,
+but [laughs] --
 
 177
-00:09:12,541 --> 00:09:16,246
-I'm
+00:09:11,700 --> 00:09:12,300
+Dan: No biggie.
+
+178
+00:09:13,000 --> 00:09:16,246
+Bekah: That's all. So, all
+right. I'm
 
 178
 00:09:16,246 --> 00:09:19,067
-going to check out the chat now.
-That's my, my Kirk origin story,
+gonna check out the chat now.
+That's my- my Kirk origin story,
 
 179
 00:09:19,067 --> 00:09:22,336
 and this is how he's become to
-be my best friend ever
+be my best friend ever since.
+
+---
 
 180
 00:09:22,336 --> 00:09:27,047
-Dan: since. Yeah. So we just
+Dan: Yeah. So we just
 got a comment from David saying,
 
 181

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -168,11 +168,11 @@ Bekah: We are coming here, live
 29
 00:01:34,156 --> 00:01:37,816
 from Lakewood, Ohio. We are
-celebrating national Kirk day or
+celebrating national Kirk Day or
 
 30
 00:01:37,816 --> 00:01:40,757
-international Kirk day as we
+international Kirk Day as we
 more fondly know it at Virtual
 
 31
@@ -181,7 +181,7 @@ Coffee.
 
 32
 00:01:41,596 --> 00:01:42,337
-Dan: Intergalactic Kirk day?
+Dan: Intergalactic Kirk Day?
 
 33
 00:01:43,996 --> 00:01:47,147
@@ -195,7 +195,7 @@ Dimensional -- interdimensional
 
 35
 00:01:49,500 --> 00:01:50,057
-Kirk day.
+Kirk Day.
 
 36
 00:01:50,057 --> 00:01:50,656
@@ -2060,16 +2060,14 @@ it's all on the podcast. But
 there's been some- there's been
 some- there's been some moments.
 
----
-
 332
 00:17:42,477 --> 00:17:43,842
 Bekah: Yeah. Yeah. There are
-many moments on the podcast
+many moments on the podcast.
 
 333
 00:17:43,842 --> 00:17:45,207
-we've
+We've
 
 334
 00:17:45,207 --> 00:17:46,646
@@ -2083,73 +2081,93 @@ would
 336
 00:17:48,086 --> 00:17:49,541
 laugh uncontrollably for the
-first five minutes. I could
+first five minutes and I could
 
 337
 00:17:49,541 --> 00:17:50,996
 never
 
 338
-00:17:50,997 --> 00:17:54,446
-do the introduction. I maybe
-there's. I don't know if there's
+00:17:50,997 --> 00:17:54,000
+do the introduction. I -- maybe
+there's -- I don't know if
 
 339
-00:17:54,446 --> 00:17:54,567
-any,
+00:17:54,000 --> 00:17:55,000
+there's any [inaudible]
+[laughs].
 
 340
-00:17:55,797 --> 00:17:58,346
-Dan: for sure. We sure have it
-all recorded. I don't know if,
+00:17:55,797 --> 00:17:56,700
+Dan: No, we have it all on tape,
+for sure. We sure have it all
+
+341
+00:17:56,700 --> 00:17:58,346
+recorded. I don't know if,
 
 341
 00:17:58,346 --> 00:18:00,566
 yeah. I don't know how much
-video we have of it, but like,
-
-342
-00:18:00,566 --> 00:18:02,786
-we
+video we have of it, but, like,
 
 343
-00:18:02,787 --> 00:18:05,727
-have a lot of views of, of like
-trying to do the intros and
+00:18:02,787 --> 00:18:04,500
+we have a lot of views of- of
+the, like, trying to do the
 
 344
-00:18:05,727 --> 00:18:07,526
-stuff. It's so funny. Cause
-you're so good at it. Like
+00:18:04,500 --> 00:18:05,500
+intros and stuff.
 
-345
-00:18:07,526 --> 00:18:09,325
-you're
+00:18:05,500 --> 00:18:06,700
+Bekah: I just couldn't [laughs].
+I just would -- just --
+
+00:18:06,700 --> 00:18:09,000
+Dan: It's so funny. Cuz you're
+so good at it. Like,
 
 346
-00:18:09,326 --> 00:18:12,896
-so good at like this stuff most
-of the time and like it's the
+00:18:09,000 --> 00:18:12,500
+you're so good at, like, this
+stuff most of the time. And like
 
 347
-00:18:12,896 --> 00:18:15,057
-recorded nature of it. It's like
-the reading, the script
+00:18:12,500 --> 00:18:14,700
+-- it's the recorded nature of
+it. It's like the reading the
 
 348
-00:18:15,057 --> 00:18:18,836
-Bekah: part. It was like, I was
-so nervous. Like I was like
+00:18:14,700 --> 00:18:15,057
+script part-
+
+348
+00:18:15,057 --> 00:18:15,500
+Bekah:  It was like-
+
+00:18:15,300 --> 00:18:16,000
+Dan: I felt that- I felt that --
+
+00:18:15,500 --> 00:18:16,700
+Bekah: -I was so nervous.
+
+00:18:16,700 --> 00:18:18,000
+Dan: Yeah. That was [inaudible].
+
+00:18:17,000 --> 00:18:18,700
+Bekah: Like, it [laughs] It was,
+like,
 
 349
 00:18:18,866 --> 00:18:22,076
 nervousness decided to turn
-itself into laughters and like I
+itself into laughters. And like,
 
 350
 00:18:22,076 --> 00:18:25,676
-could not stop, which I guess is
-like better than crying or
+I could not stop. Which I guess
+is, like, better than crying or
 
 351
 00:18:25,676 --> 00:18:29,067
@@ -2158,143 +2176,164 @@ through those phases as well.
 
 352
 00:18:29,217 --> 00:18:32,547
-Dan: Yeah, definitely one of my
-main skills.
+Dan: Yeah, sweat is definitely
+one of my main skills.
 
 353
-00:18:34,317 --> 00:18:38,231
+00:18:34,317 --> 00:18:36,000
 Bekah: Just checking out the
-chat. Promoted to customer.
+chat.
 
 354
-00:18:41,741 --> 00:18:48,392
-Dan: Yes. Congratulations. I
-don't know pressure valves.
+00:18:36,000 --> 00:18:36,300
+Dan: Yeah.
 
 355
-00:18:50,432 --> 00:18:51,542
-Bekah: Yeah. As soon as he
+00:18:37,000 --> 00:18:38,231
+Bekah: Promoted to customer
+[all laugh].
+
+354
+00:18:41,741 --> 00:18:47,700
+Dan: Yes. Congratulations,
+[inaudible]. Some -- I don't
+
+355
+00:18:47,700 --> 00:18:48,392
+know. Pressure valves?
+
+355
+00:18:48,392 --> 00:18:52,300
+Bekah: [Laughs] Yeah, Suze. He
 probably would fire me for all
 
-356
-00:18:51,542 --> 00:18:52,652
-of
-
 357
-00:18:52,652 --> 00:18:58,922
-this it's okay. Oh my sure. I'm
-an introvert. I dunno. I feel
+00:18:52,300 --> 00:18:58,000
+of this. It's okay. [Laughs] Oh,
+am I sure I'm an introvert? I
+
+358
+00:18:58,000 --> 00:18:58,922
+dunno. I feel
 
 358
 00:18:58,922 --> 00:19:03,541
-like maybe I'm an ambivert
-ambivert. I am especially like
+like maybe I'm an amvivert --
+ambivert? I am, especially, like
 
 359
 00:19:03,541 --> 00:19:07,862
-intensely nervous and shy and
+intensely nervous, and shy, and
 exhausted when I'm around people
 
 360
-00:19:07,862 --> 00:19:11,612
-that I don't know. But like when
-I'm around people that I know or
+00:19:07,862 --> 00:19:10,700
+that I don't know. But like,
+when I'm around people that I
 
 361
-00:19:11,612 --> 00:19:13,951
-people that I'm friends with
-and, I can often like find
+00:19:10,700 --> 00:19:11,612
+know or
 
-362
-00:19:13,951 --> 00:19:16,290
-that
+361
+00:19:11,612 --> 00:19:15,700
+people that I'm friends with,
+then I can often, like, find
 
 363
-00:19:16,291 --> 00:19:18,241
-energy. I think that extroverts
+00:19:15,700 --> 00:19:18,241
+that energy I think that
+extroverts have.
 
 364
 00:19:18,241 --> 00:19:24,692
-Dan: have, for me, it's, for me,
-it's sort of knowing exactly
+Dan: For- for me, it's -- for
+me, it's sort of knowing exactly
 
 365
-00:19:24,692 --> 00:19:28,862
-what, like I was supposed to do
-in a situation. That's what I'm
+00:19:24,692 --> 00:19:26,700
+what, like, I was supposed to
+do with-
 
 366
-00:19:28,862 --> 00:19:32,922
-comfortable. Right. And so like
-the. This is just you and me
+00:19:26,700 --> 00:19:27,000
+Bekah: Yeah.
+
+367
+00:19:27,000 --> 00:19:29,500
+Dan: -in a situation. That's
+what I'm comfortable,
+
+366
+00:19:29,500 --> 00:19:32,922
+right? And so, like, the -- this
+is just you and me
 
 367
 00:19:32,922 --> 00:19:35,261
-chatting, you know, and like,
-we've practiced this obviously.
+chatting, you know? And like,
+we've practiced this, obviously.
 
 368
 00:19:35,261 --> 00:19:36,192
-So it's like, you
+So it's like, you know, talking,
+like --
 
 369
-00:19:36,192 --> 00:19:36,342
-Bekah: know,
+00:19:36,192 --> 00:19:38,500
+Bekah: We didn't practice this.
+But like, we've been [laughs] --
 
 370
-00:19:38,771 --> 00:19:40,916
-Dan: can't you tell we did,
-like, we did like, this is
+00:19:38,000 --> 00:19:40,916
+Dan: Well, I -- no. Can't you
+tell? We did, like- we did, like
 
 371
 00:19:40,916 --> 00:19:43,061
-yeah.
+[laughs], this is, yeah.
 
 372
-00:19:43,092 --> 00:19:44,982
-Very polished, you know,
-thing. No. But what I mean
-
-373
-00:19:44,982 --> 00:19:46,872
-is
+00:19:43,092 --> 00:19:46,872
+Very polished, you know, thing.
+No. But what I mean is
 
 374
-00:19:46,872 --> 00:19:49,541
+00:19:46,872 --> 00:19:51,500
 like, I know what socially
 is expected of me in this
 
 375
-00:19:49,541 --> 00:19:52,210
+00:19:51,500 --> 00:19:52,210
 situation.
 
 376
 00:19:52,241 --> 00:19:56,471
-You know what I mean? And so if
-I'm in coffee, like one of our
+You know what I mean? And so, if
+I'm in coffee, like, one of our
 
 377
 00:19:56,471 --> 00:20:00,402
-coffee chats and in a room with
-a whole bunch of people, I don't
+coffee chats, and in a room with
+a whole bunch of people I don't
 
 378
 00:20:00,402 --> 00:20:02,832
-know. I'm not like I don't have
-a problem. Like I don't, I don't
+know, I'm not, like, I don't
+have a problem. Like, I don't- I
 
 379
-00:20:02,832 --> 00:20:06,161
-get like, awkward like that,
-but, but when I go to like
+00:20:02,832 --> 00:20:08,300
+don't get, like, awkward like
+that. But- but when I go to,
 
 380
-00:20:06,161 --> 00:20:09,490
-go to a
+00:20:08,300 --> 00:20:09,490
+like, go to a
 
 381
 00:20:09,491 --> 00:20:12,162
-conference, right. And then
+conference, right? And then,
 there's like a social hour or
 
 382
@@ -2305,101 +2344,139 @@ know people, and I don't know
 383
 00:20:15,162 --> 00:20:18,192
 exactly what I'm supposed to do
-or my role in, you know, that's
+or, like, my role in, you know,
 
 384
-00:20:18,192 --> 00:20:20,832
-when I get like, that's when I
-get like super and I just go and
+00:20:18,192 --> 00:20:18,500
+that's when I get, like-
+
+385
+00:20:18,500 --> 00:20:18,700
+Bekah: Yeah.
+
+386
+00:20:18,700 --> 00:20:20,000
+Dan: -that's when I get, like,
+super-
+
+385
+00:20:20,000 --> 00:20:20,200
+Bekah: Yep.
+
+386
+00:20:20,200 --> 00:20:20,832
+Dan: -and I just go and
 
 385
 00:20:20,832 --> 00:20:22,662
-sit down by myself and put my
-headphones on or something, or I
+sit down by myself, and put my
+headphones on or so- or -- I
 
 386
-00:20:22,662 --> 00:20:23,741
-don't put my headphones on, but
-like, cause I'm fine. If
-
-387
-00:20:23,741 --> 00:20:24,820
-somebody
+00:20:22,662 --> 00:20:24,820
+don't put my headphones on. But
+like -- cuz I'm fine if somebody
 
 388
 00:20:24,821 --> 00:20:25,856
-comes and talks to me, like,
-that's cool. Cause that's like
+comes [chuckles] and talks to
+me, like, that's cool.
 
 389
-00:20:25,856 --> 00:20:26,891
-a.
+00:20:25,856 --> 00:20:26,000
+Bekah: Yeah.
 
 390
-00:20:27,672 --> 00:20:28,557
-Hey, this is what you're
-supposed to do now, you know,
+00:20:26,000 --> 00:20:26,891
+Dan: Cuz that's like,
+
+390
+00:20:27,672 --> 00:20:29,000
+"Hey, this is what you're
+supposed to do now," you know?
 
 391
-00:20:28,557 --> 00:20:29,442
-but like
+00:20:29,000 --> 00:20:29,442
+But like,
 
 392
-00:20:29,471 --> 00:20:31,656
+00:20:29,471 --> 00:20:33,000
 walking up to somebody and
-trying to like, that's, that's
+trying to, like ... that's-
 
 393
-00:20:31,656 --> 00:20:33,841
-what I,
+00:20:33,000 --> 00:20:33,841
+that's what I --
 
 394
-00:20:34,001 --> 00:20:36,221
-like. I really struggled with
-that. That's the kind of stuff
+00:20:34,001 --> 00:20:35,300
+like, I really struggled with
+that. That-
 
 395
-00:20:36,221 --> 00:20:38,922
-that I struggled with, you know,
-is those, those like situations,
+00:20:35,300 --> 00:20:35,500
+Bekah: Yeah.
+
+396
+00:20:35,500 --> 00:20:36,700
+Dan: -that's the kind of
+stuff that I struggled with,
+
+395
+00:20:36,700 --> 00:20:38,922
+you know? Is those- those, like,
+situations ...
 
 396
 00:20:39,672 --> 00:20:45,011
-Where it's an unfamiliar
+where it's an unfamiliar
 territory or like, you know, I
 
 397
 00:20:45,011 --> 00:20:45,112
-don't know.
+dunno.
 
 398
-00:20:45,612 --> 00:20:48,311
-Bekah: Yeah. So it's like that.
-So my dad was just telling my
+00:20:45,612 --> 00:20:46,000
+Bekah: Yeah.
 
 399
-00:20:48,551 --> 00:20:52,031
-oldest, my 12 year old, he was
-talking about how great it is to
+00:20:46,000 --> 00:20:47,000
+Dan: Something like that. So -- 
 
 400
-00:20:52,031 --> 00:20:53,846
-talk to random people in the
-garb and talking to them like
+00:20:47,000 --> 00:20:48,311
+Bekah: My dad was just telling
+my-
 
 401
-00:20:53,846 --> 00:20:55,661
+00:20:48,311 --> 00:20:48,551
+Dan: Super [inaudible].
+
+399
+00:20:48,551 --> 00:20:51,500
+Bekah: -oldest — my 12 year old
+— he was talking about how great
+
+400
+00:20:51,500 --> 00:20:54,500
+it is to talk to, like, random
+people, and to go up and talking
+
+401
+00:20:54,500 --> 00:20:56,142
+to them, like, "Dad, that is-
 that is
 
 402
 00:20:56,142 --> 00:20:58,511
-a terrible thing. My dad loves
-it. Like he will go up to any
+a terrible thing." My dad loves
+it. Like, he will go up to any
 
 403
 00:20:58,511 --> 00:21:01,541
-person and he will probably try
-and say what their name, he'll
+person, and he will probably try
+and say what their na- he'll
 
 404
 00:21:01,541 --> 00:21:04,031
@@ -2412,285 +2489,419 @@ throughout the conversation, but
 then forget their name and use a
 
 406
-00:21:06,551 --> 00:21:11,711
-different name. That's wrong. He
-tries very hard to be personal.
+00:21:06,551 --> 00:21:08,000
+different name that's wrong
+[laughs].
 
 407
-00:21:12,221 --> 00:21:16,362
-But that was like, my
-worst nightmare talking to a
+00:21:09,500 --> 00:21:10,000
+Dan: [Laughs] That's awesome.
 
 408
-00:21:16,362 --> 00:21:18,521
-stranger that I don't know about
-things.
+00:21:10,000 --> 00:21:11,000
+Bekah: He tries very hard to be
+personal.
+
+407
+00:21:11,700 --> 00:21:12,000
+Dan: Yeah.
+
+407
+00:21:12,500 --> 00:21:15,700
+Bekah: But there's, like, my
+worst nightmare talking to a-
+
+00:21:15,700 --> 00:21:16,000
+Dan: Yeah.
+
+408
+00:21:16,362 --> 00:21:18,000
+Bekah: -stranger that I don't
+know about things.
 
 409
-00:21:19,241 --> 00:21:21,101
-Dan: Yeah. No, my father-in-law
-is huge big on that. And he was
+00:21:17,500 --> 00:21:19,000
+Dan: Yeah. Yeah.
 
 410
-00:21:21,101 --> 00:21:22,961
-a
+00:21:19,000 --> 00:21:19,500
+Bekah: I can't.
+
+411
+00:21:20,000 --> 00:21:22,500
+Dan: Yeah. No, my father-in-law
+is huge -- he big on that. And
+
+410
+00:21:22,500 --> 00:21:22,961
+he was a bartender
 
 411
 00:21:22,961 --> 00:21:25,571
-bartender and stuff and like, he
-just doesn't naturally, like, he
+and stuff. And like, he just
+doesn't naturally -- like, he
 
 412
 00:21:25,571 --> 00:21:29,382
 doesn't almost like impulsively,
-you know, but like, like, in
+you know? But like- like, in
 
 413
 00:21:29,382 --> 00:21:32,172
 an elevator or something, he'll
-just like chat up and they
+just like chat up, and they
 
 414
-00:21:32,172 --> 00:21:34,541
-probably don't want to talk to
-him. I mean, like not like he's
+00:21:32,172 --> 00:21:34,000
+probably don't wanna talk to
+him. Well, I mean, like -- not
 
 415
-00:21:34,541 --> 00:21:35,741
-not being creepy. Right. And
-he's not like hitting on anybody
+00:21:34,000 --> 00:21:35,741
+like -- he's not being creepy or
+anything.
 
 416
-00:21:35,741 --> 00:21:36,941
-or
+00:21:35,741 --> 00:21:36,000
+Bekah: Right.
 
 417
-00:21:36,942 --> 00:21:37,662
-anything like that, but he's.
+00:21:35,800 --> 00:21:36,942
+Dan: And he's not, like, hitting
+on anybody or
+
+417
+00:21:36,942 --> 00:21:39,281
+anything like that. But he would
+just like ... talking to them.
 
 418
-00:21:38,741 --> 00:21:39,281
-Bekah: Talking to them.
+00:21:39,281 --> 00:21:40,000
+Bekah: He would be friends with
+my- my dad [laughs].
 
 419
-00:21:42,791 --> 00:21:45,011
-Dan: great guy. You know what I
-mean? And like, but that's just
+00:21:40,000 --. 00:21:40,700
+Dan: [Laughs] Right, right.
+Yeah.
 
 420
-00:21:45,071 --> 00:21:48,101
-how he is, you know? Yeah.
-Somebody said something
+00:21:40,700 --> 00:21:42,791
+Bekah: They would talk to each
+other in the elevator.
+
+419
+00:21:42,791 --> 00:21:42,800
+Dan: It was fun for the break.
+He's, like, great
+
+420
+00:21:42,800 --> 00:21:45,011
+guy. You know what I mean? And
+like, but that's just
+
+420
+00:21:45,071 --> 00:21:50,000
+how he is, you know?  And ...
+yeah. Somebody said something
 
 421
-00:21:48,101 --> 00:21:51,131
-about
+00:21:50,000 --> 00:21:51,131
+about --
 
 422
 00:21:52,031 --> 00:21:53,111
-Joe said, so what do I do with
-my hands? That's a big thing
+Joe said some- "What do I do
+with my hands?" That's a big
 
 423
-00:21:53,111 --> 00:21:54,191
-with me
+00:21:53,111 --> 00:21:55,300
+thing with me too. And honestly,
 
 424
-00:21:54,192 --> 00:21:57,701
-too. And honestly that's like
-what I, one of the things I like
+00:21:55,300 --> 00:21:57,701
+that's like -- what I -- one of
+the things I like
 
 425
-00:21:57,701 --> 00:22:01,541
-about the, this, this phase in
-our collective lives of the zoom
+00:21:57,701 --> 00:22:01,000
+about the -- this- this phase in
+our, like, collective lives of
 
 426
-00:22:01,541 --> 00:22:04,481
-stuff is that most times, so
-right now my camera's like
+00:22:01,000 --> 00:22:03,700
+the Zoom stuff is that most
+times -- so right now, my
 
 427
-00:22:04,481 --> 00:22:05,651
-scooted back a little bit so
-that we can both fit in. Most
+00:22:03,700 --> 00:22:05,651
+camera's like scooted back a
+little bit so that we can both
 
 428
-00:22:05,651 --> 00:22:06,821
-time you
+00:22:05,651 --> 00:22:17,500
+fit in. Most time, you can't see
 
 429
-00:22:06,821 --> 00:22:10,332
-can see my hands. And I've
-honestly, like during this thing
+00:22:17,500 --> 00:22:10,700
+my hands. And I've, honestly,
+like, during this thing, I had
 
 430
-00:22:10,602 --> 00:22:14,652
-had been like seeing my hands in
-the video and been like, oh God,
+00:22:10,700 --> 00:22:14,300
+been, like, seeing my hands in
+the video, and been like, "Oh,
 
 431
-00:22:14,682 --> 00:22:16,811
-get these out of here. You know?
-Cause I'm just like, like, I
+00:22:14,300 --> 00:22:16,811
+god. Get these out of here," you
+know? Cuz I'm just like- like, I
 
 432
 00:22:16,811 --> 00:22:17,936
-don't know, what do I do with my
+don't know. What do I do with my
 hands? Big problem. Yeah. What
 
-433
-00:22:17,936 --> 00:22:19,061
-do
-
 434
-00:22:19,061 --> 00:22:23,922
-I do with my whole body? Like
-standing in a group of people.
+00:22:19,061 --> 00:22:23,300
+do I do with my whole body?
+Like, standing in a group of
 
 435
-00:22:24,807 --> 00:22:28,047
-How do I stay? You know, like
-seriously, like I I've struggled
+00:22:24,300 --> 00:22:26,300
+people. How do I stand? You
+know? Like [chuckles],
 
 436
-00:22:28,047 --> 00:22:31,076
-with that. You know, like I do
-just put my hands in my pockets
+00:22:26,300 --> 00:22:27,000
+seriously, like, I -- I've --
+
+437
+00:22:27,000 --> 00:22:27,300
+Bekah: Yeah.
+
+438
+00:22:27,300 --> 00:22:28,700
+Dan: -I've struggled with that,
+you know?
+
+436
+00:22:28,700 --> 00:22:31,076
+Like, I don't -- do I just put
+my hands in my pockets
 
 437
 00:22:31,136 --> 00:22:31,977
-or, you know, I don't
+or, you know? I dunno.
 
 438
-00:22:31,977 --> 00:22:34,616
-Bekah: know. I like pockets and
-I just don't make enough pockets
+00:22:31,977 --> 00:22:34,000
+Bekah: That's why I like
+pockets.
 
 439
-00:22:34,616 --> 00:22:37,826
-for women. It's like, even
-earlier, Dan and I were like
+00:22:33,700 --> 00:22:34,000
+Dan: Yeah, yeah.
+
+439
+00:22:34,000 --> 00:22:34,616
+Bekah: And they just don't make
+enough pockets for women.
 
 440
-00:22:37,826 --> 00:22:41,247
-sitting at this conference table
-talking like I move around a lot
+00:22:34,616 --> 00:22:35,000
+Dan: Yeah. Yeah.
+
+439
+00:22:35,000 --> 00:22:36,000
+Bekah: It's like, even earlier-
+
+00:22:36,300 --> 00:22:37,000
+Dan: Pockets is -- are great.
 
 441
-00:22:41,247 --> 00:22:45,416
-and I've like recently become
-more aware of how much I move by
+00:22:36,500 --> 00:22:37,500
+Bekah: -I -- we're -- Dan and I
+were like sitting
+
+440
+00:22:37,500 --> 00:22:41,247
+at this conference table talking
+-- like, I move around a lot,
+
+441
+00:22:41,247 --> 00:22:43,000
+and I've, like, recently, become
+more aware-
+
+442
+00:22:43,000 --> 00:22:43,300
+Dan: Mm-hmm.
+
+443
+00:22:43,500 --> 00:22:45,416
+Bekah: -of how much I move by
 
 442
 00:22:45,416 --> 00:22:48,297
 seeing other people on camera.
-And then I'm like constantly, I
+And then I'm like constant- I
 
 443
 00:22:48,297 --> 00:22:50,247
 think someone once gave me like
-feedback, don't move your hands
+feedback, "Don't move your hands
 
 444
-00:22:50,247 --> 00:22:53,487
-so much. It's distracting. Like
-whatever, like I'm gonna move my
+00:22:50,247 --> 00:22:53,000
+so much. It's distracting."
+Like, whatever. Like, I'm gonna
 
 445
-00:22:53,487 --> 00:22:56,967
-hands as much as I want it
-because I can't. I said, we've
+00:22:53,000 --> 00:22:53,487
+move my
+
+445
+00:22:53,487 --> 00:22:56,300
+hands as much as I want it.
+Like, because I can. I said, I
+
+446
+00:22:56,300 --> 00:22:56,967
+-- we've
 
 446
 00:22:56,967 --> 00:23:00,356
-got spinny, Dan's got so many
-chairs. So I got to do a lot of
+got spinny -- Dan's got spinny
+chair. So I got to do a lot of
 
 447
-00:23:00,356 --> 00:23:03,176
-spinning. This is, this is what
-I do. I move all the time. But
-
-448
-00:23:03,176 --> 00:23:05,996
-like
+00:23:00,356 --> 00:23:04,700
+spinning [chuckles]. This is-
+this is what I do. I move all
 
 449
-00:23:05,997 --> 00:23:07,907
-when I'm in front of the camera
-in my office, like I very much,
+00:23:04,700 --> 00:23:05,700
+the time. But, like-
+
+450
+00:23:05,700 --> 00:23:06,700
+Dan: Yeah. You do it a lot too.
+
+451
+00:23:05,750 --> 00:23:07,907
+Bekah: -when I'm in front of the
+camera in my office,
 
 450
 00:23:07,907 --> 00:23:09,817
-I
+like, I very much try -- I- I
 
 451
-00:23:09,836 --> 00:23:14,997
+00:23:09,836 --> 00:23:13,000
 have to try very hard to sit
-still and not move my hands
+still [chuckles]-
+
+452
+00:23:13,000 --> 00:23:13,300
+Dan: Yeah.
+
+453
+00:23:13,500 --> 00:23:14,997
+Bekah: -and not move my hands
 
 452
 00:23:14,997 --> 00:23:17,757
 everywhere because that is not
-my natural state of.
+my natural state of being.
 
 453
-00:23:23,136 --> 00:23:25,747
-Dan: I ended there. Yes.
+00:23:17,757 --> 00:23:19,500
+Dan: It's hard. [Bekah chuckles]
+It's hard.
+
+453
+00:23:23,136 --> 00:23:26,497
+Waving your hair -- ha-hands in
+the air. Yes. Joe said --
 
 454
-00:23:26,497 --> 00:23:29,467
-Bekah: we do the wave one time
-at Virtual Coffee in my breakout
+00:23:26,497 --> 00:23:28,500
+Bekah: We did the wave one time
+at Virtual Coffee-
+
+455
+00:23:28,500 00:23:29,000
+Dan: Ooh, right.
+
+456
+00:23:28,550 --> 00:23:29,467
+Bekah: -in my breakout
 
 455
 00:23:29,467 --> 00:23:33,457
-room. We like, we, we
-alphabetized everybody and then
+room. We, like, alf- we- we
+alphabetized everybody, and then
 
 456
 00:23:33,576 --> 00:23:35,946
-everybody went, it was very
-exciting
+everybody went. It was very
+exciting.
 
 457
-00:23:39,997 --> 00:23:48,156
-Dan: to Minnesota. Marie had to
-go yeah,
+00:23:39,997 --> 00:23:43,000
+Dan: Do we miss -- oh, no. Oh,
+Marie had to go.
 
 458
-00:23:49,017 --> 00:23:51,162
-Bekah: we should. Is, is
+00:23:43,000 --> 00:23:44,300
+Bekah: Oh, Marie.
+
+459
+00:23:44,300 --> 00:23:49,000
+Dan: We will see you, Marie. Um,
+yeah. I dunno.
+
+458
+00:23:49,017 --> 00:23:53,000
+Bekah: We should -- is- is
 Kirk around? Can we bring Kirk
 
 459
-00:23:51,162 --> 00:23:53,307
+00:23:53,000 --> 00:23:53,307
 on?
 
 460
-00:23:54,326 --> 00:24:02,547
-Dan: I dunno, it is, Kirk
-day, which is where we started.
+00:23:54,326 --> 00:24:00,000
+Dan: I dunno. It is Kirk Day.
 
 461
-00:24:02,606 --> 00:24:08,007
-He responded well, that was 20
-minutes ago, I guess. Are you
+00:24:01,000 --> 00:24:02,606
+Bekah: Which is why we started.
+
+461
+00:24:02,606 --> 00:24:06,000
+Dan: He responded to [inaudible]
+well, that was 20 minutes ago,
 
 462
-00:24:08,007 --> 00:24:11,547
-dealing in, should I give him
-okay. We'll see if I can get
+00:24:06,000 --> 00:24:09,000
+I guess. Are you DM him? Or
+should I DM him?
 
 463
-00:24:11,547 --> 00:24:12,971
-Bekah: her on him. Our
-celebrity, our resident
+00:24:09,000 --> 00:24:09,700
+Bekah: I DMed him.
 
 464
-00:24:12,971 --> 00:24:14,395
-celebrity.
+00:24:09,700 --> 00:24:12,000
+Dan: Okay. We'll see if we can
+get Kirk on here.
+
+463
+00:24:12,000 --> 00:24:14,395
+Bekah: Our celebrity. Our
+resident celebrity.
 
 465
 00:24:15,416 --> 00:24:20,027
@@ -2698,142 +2909,209 @@ Dan: It'll be funny. Because
 once we get another person on
 
 466
-00:24:20,027 --> 00:24:26,781
-this call, You and me we'll be
-in one box and, oh man, this
+00:24:20,027 --> 00:24:24,000
+this call, you and me, we'll be
+in one box. And Kirk will be in
+
+00:24:24,000 --> 00:24:25,000
+another one [laughs].
+
+00:24:25,000 --> 00:24:25,300
+Bekah: Yeah.
+
+00:24:26,000 --> 00:24:27,700
+Dan: Oh, man. It's crazy. It's
+crazy.
 
 467
-00:24:26,791 --> 00:24:31,342
-Bekah: is crazy. Rick is at
-work. What's word two people do
-
-468
-00:24:31,342 --> 00:24:31,761
-Kirk Shillingford: that.
+00:24:28,000 --> 00:24:31,342
+Bekah: Kirk is at work. What's
+work? Do people do that?
 
 469
 00:24:32,662 --> 00:24:37,192
 Dan: Don't they know it's Kirk
-day. I'm pretty sure they do
+Day? I'm pretty sure they do.
 
 470
-00:24:37,192 --> 00:24:37,642
-because,
+00:24:37,192 --> 00:24:39,000
+Because they is --
 
 471
 00:24:38,342 --> 00:24:40,981
-Bekah: well, I mean, maybe we
-could have any Kirk, Nick has
+Bekah: Oh, I mean, maybe we
+can have any Kirk. Nick has
 
 472
-00:24:40,981 --> 00:24:42,526
+00:24:40,981 --> 00:24:41,500
 asked. That's a good question.
-So in our slack right now, most
 
-473
-00:24:42,526 --> 00:24:44,071
-of
+00:24:41,500 --> 00:24:42,000
+Dan: Ooh.
+
+00:24:42,000 --> 00:24:44,071
+Bekah: So, in our Slack right
+now, most of
 
 474
 00:24:44,071 --> 00:24:49,422
-us have. Put our profile down,
-flipped it and reversed it. But
+us have put our profile down,
+flipped it, and reversed it. But
 
 475
 00:24:49,422 --> 00:24:50,082
-with Kirk's
+with Kirk's --
 
 476
-00:24:50,561 --> 00:24:57,971
-Dan: I see him Kirk, or we're
-going to try to get Kirk in to
+00:24:50,561 --> 00:24:52,000
+Dan: Huh. I see him. Kiirk.
 
 477
-00:24:59,291 --> 00:25:06,402
-Bekah: join. Remember how to we
-are, sorry. We're doing our best
+00:24:52,000 --> 00:24:53,000
+Bekah: Kiirk.
 
 478
-00:25:06,402 --> 00:25:09,007
+00:24:52,500 --> 00:24:55,000
+Dan: Alright, alright. Hang on
+there a second. I'll
+
+479
+00:24:55,000 --> 00:24:59,500
+[inaudible]. Alright. We're
+gonna try to get Kirk in to
+
+480
+00:24:59,500 --> 00:24:59,700
+join.
+
+481
+00:24:59,700 --> 00:25:01,700
+Bekah: We're doing out best. If
+we disappoint you-
+
+477
+00:25:01,300 --> 00:25:03,500
+Dan: I just have- I just have to
+remember how, you know,
+
+478
+00:25:03,500 --> 00:25:04,000
+[inaudible].
+
+479
+00:25:04,000 --> 00:25:06,402
+Bekah: -we're sorry. We're doing
+our best
+
+478
+00:25:06,402 --> 00:25:08,000
 to bring our celebrity on the
-stream. At least take 10 fakes
+stream.
+
+479
+00:25:08,000 --> 00:25:09,000
+Dan: Him is celebrity.
 
 479
 00:25:09,007 --> 00:25:11,612
-in
+Bekah: At least take -- 10 fakes
+in- in
 
 480
-00:25:11,622 --> 00:25:13,211
-the chat as well. I want to
-shout out to Abby Perini because
-
-481
-00:25:13,211 --> 00:25:14,800
-she
+00:25:11,622 --> 00:25:14,800
+the chat as well. I wanna shout
+out to Abbey Perini because she
 
 482
-00:25:14,801 --> 00:25:18,731
-DME last night, she was like,
-after midnight, put up this in
+00:25:14,801 --> 00:25:18,000
+DMed me last night. She was
+like, "After midnight, put up
 
 483
-00:25:18,731 --> 00:25:21,296
-your profile. So Abby has been
-an amazing observer of Kirk day,
+00:25:18,000 --> 00:25:22,700
+this in your profile. So, Abbey
+has been an amazing observer of
 
 484
-00:25:21,296 --> 00:25:23,861
-and
+00:25:22,700 --> 00:25:23,861
+Kirk Day, and
 
 485
-00:25:23,862 --> 00:25:29,416
+00:25:23,862 --> 00:25:26,000
 I could not have asked for
-anything better. We don't want
+anything better.
 
 486
-00:25:29,426 --> 00:25:36,086
-break. Where are we breaking out
-to turn off the world, please
+00:25:26,000 --> 00:25:29,300
+Dan: Oh, breakout rooms. I don't
+think we need breakout rooms.
 
 487
-00:25:36,086 --> 00:25:38,396
-stand up. Yes. Oh my goodness.
-We definitely need to, find
+00:25:28,700 --> 00:25:31,500
+Bekah: We don't want breakout
+[inaudible] [all chuckle] --
+
+486
+00:25:31,500 --> 00:25:32,700
+where are we breaking out
+to?
+
+487
+00:25:33,000 --> 00:25:35,000
+Dan: I was trying to turn off the
+[inaudible].
+
+487
+00:25:34,300 --> 00:25:37,700
+Bekah: Will the real slim Kirk
+please stand up. Yes. Oh, my
 
 488
-00:25:38,396 --> 00:25:40,706
-more
+00:25:37,700 --> 00:25:42,300
+goodness. We definitely need to
+find more ways to put Kirk into
 
 489
-00:25:40,707 --> 00:25:42,686
-ways to put Kirk into music.
+00:25:42,300 --> 00:25:42,686
+music.
 
 490
 00:25:43,106 --> 00:25:46,586
-Dan: All right. Kirk said he can
-join in three minutes. So we
+Dan: All right. Kirk said, he
+can join in three minutes. So-
 
 491
-00:25:46,586 --> 00:25:50,066
-just
+00:25:46,586 --> 00:25:46,800
+Bekah: Should we-
 
 492
-00:25:50,067 --> 00:25:51,251
-talked about this book for, I
-don't know, jokes. I can't
+00:25:46,700 --> 00:25:47,700
+Dan: -we have -- we --
+[unintelligible].
 
 493
-00:25:51,251 --> 00:25:52,435
-really
+00:25:46,800 --> 00:25:48,500
+Bekah: -tell jokes? Tell joke.
+Joke.
+
+494
+00:25:48,500 --> 00:25:50,700
+Dan: I don't -- I'm not -- we
+just talk about [unintelligible]
+
+492
+00:25:50,700 --> 00:25:52,586
+for. I don't know jokes. I
+can't remember them.
 
 494
 00:25:52,586 --> 00:25:56,457
-Bekah: all right. I'll tell my
-joke. Have you all one about
+Bekah: All right. I'll tell my
+joke. Have you all [??] [laughs]
 
 495
 00:25:56,457 --> 00:25:57,146
-pizza?
+don't want about pizza?
 
 496
 00:25:59,916 --> 00:26:00,936
@@ -2842,24 +3120,25 @@ one.
 
 497
 00:26:03,817 --> 00:26:05,616
-Bekah: Nevermind. It's cheesy.
+Bekah: [Laughs] Nevermind. It's
+too cheesy for pizza.
 
 498
 00:26:09,717 --> 00:26:10,106
-Dan: Man.
+Dan: Oh, man.
 
 499
 00:26:11,247 --> 00:26:14,517
-Bekah: Well, we do the podcast.
+Bekah: When we do the podcast,
 Dan always wants me to adjust my
 
 500
-00:26:14,517 --> 00:26:16,527
-microphone. And so then I try
+00:26:14,517 --> 00:26:18,000
+microphone. And so then, I try
 and tell him jokes, which he
 
 501
-00:26:16,527 --> 00:26:18,537
+00:26:18,000 --> 00:26:18,537
 ignores
 
 502
@@ -2868,36 +3147,38 @@ all of the time. And then some
 of our guests are nice enough to
 
 503
-00:26:22,676 --> 00:26:24,506
-laugh. So if you come on the
+00:26:22,676 --> 00:26:25,700
+laugh. So, if you come on the
 podcast, please laugh at my
 
-504
-00:26:24,506 --> 00:26:26,336
-jokes
-
 505
-00:26:26,906 --> 00:26:30,011
-and roll your eyes that day.
-Please encourage me in my
+00:26:25,700 --> 00:26:28,000
+jokes and roll your eyes at Dan.
 
 506
-00:26:30,011 --> 00:26:33,116
-keynote
+00:26:28,000 --> 00:26:29,000
+Dan: Don't encourage her.
 
 507
-00:26:33,116 --> 00:26:34,856
-talk that I'm giving in July.
-I'm just telling jokes for 15
+00:26:29,500 --> 00:26:33,000
+Bekah: Please encourage me
+[laughs]. In my keynote-
 
 508
-00:26:34,856 --> 00:26:36,596
-minutes
+00:26:33,000 --> 00:26:33,300
+Dan: You know --
+
+507
+00:26:33,116 --> 00:26:36,000
+Bekah: -talk that I'm giving in
+July, I'm just telling jokes for
 
 509
-00:26:36,596 --> 00:26:38,606
-straight because I can do
-whatever I want.
+00:26:36,000 --> 00:26:38,606
+15 minutes straight because I
+can do whatever I want.
+
+---
 
 510
 00:26:39,176 --> 00:26:41,817
@@ -3669,7 +3950,7 @@ this either, but
 
 674
 00:35:53,967 --> 00:35:55,586
-Dan: since it's Kirk day, do you
+Dan: since it's Kirk Day, do you
 want to back.
 
 675
@@ -5190,7 +5471,7 @@ make that
 
 999
 00:52:32,246 --> 00:52:33,656
-Bekah: Kurt, Kurt is Kirk day.
+Bekah: Kurt, Kurt is Kirk Day.
 You were allowed to ask him to
 
 1000
@@ -5966,7 +6247,7 @@ Bekah: birthday
 1165
 01:01:22,452 --> 01:01:30,702
 Dan: week. Kirk, I just want
-to say a happy Kirk day to us
+to say a happy Kirk Day to us
 
 1166
 01:01:30,702 --> 01:01:31,001
@@ -5988,7 +6269,7 @@ me as a catalyst for the pool.
 
 1170
 01:01:44,181 --> 01:01:48,282
-People here, Kirk day is weird,
+People here, Kirk Day is weird,
 but the people who like it are
 
 1171
@@ -6017,7 +6298,7 @@ done today. It was
 1176
 01:02:05,512 --> 01:02:09,282
 Bekah: a, but most importantly,
-we saw Kirk on Kirk day and
+we saw Kirk on Kirk Day and
 
 1177
 01:02:09,282 --> 01:02:10,481
@@ -6062,7 +6343,7 @@ Thursday.
 1186
 01:02:38,396 --> 01:02:49,376
 Kirk: No, don't do another one
-no more Kirk days. Yeah, every
+no more Kirk Days. Yeah, every
 
 1187
 01:02:49,376 --> 01:02:57,806

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -1039,8 +1039,6 @@ That's my- my Kirk origin story,
 and this is how he's become to
 be my best friend ever since.
 
----
-
 180
 00:09:22,336 --> 00:09:27,047
 Dan: Yeah. So we just
@@ -1048,210 +1046,260 @@ got a comment from David saying,
 
 181
 00:09:27,057 --> 00:09:28,876
-so cool to see you in the same
-place, physical physically, yet.
+"So cool to see you in the same
+place -- physical place." Yeah.
 
 182
 00:09:28,907 --> 00:09:31,216
 This is the first time that we
-have like actually met in real
+have, like, actually met in real
 
 183
 00:09:31,216 --> 00:09:34,226
 life. And we started working
-with. When did we start
+together ... when did we start
 
 184
-00:09:34,226 --> 00:09:36,567
-Bekah: working together? July?
-This will be, so it would,
+00:09:34,226 --> 00:09:34,700
+working together?
 
-185
-00:09:36,567 --> 00:09:37,496
-would've been three years
+184
+00:09:34,700 --> 00:09:37,496
+Bekah: July -- this will be --
+so, it would've been three years
 
 186
-00:09:37,496 --> 00:09:40,437
-Dan: in July before Virtual
-Coffee. Like we were working
+00:09:37,496 --> 00:09:37,700
+in July.
 
 187
-00:09:40,437 --> 00:09:41,726
-together before it started
+00:09:37,700 --> 00:09:39,500
+Dan: Yeah. Before -- I mean,
+bef- before Virtual Coffee.
 
 188
-00:09:42,356 --> 00:09:44,746
+00:09:39,500 --> 00:09:40,000
+Like, we were working-
+
+189
+00:09:40,000 --> 00:09:40,300
+Bekah: Yeah.
+
+187
+00:09:40,437 --> 00:09:43,700
+Dan: -together before Virtual
+Coffee started. And -- I mean --
+
+188
+00:09:42,356 --> 00:09:44,700
 Bekah: Dan fired me. And that's
 how Virtual Coffee started
 
 189
-00:09:44,746 --> 00:09:45,891
-Dan: As soon as I said that, I
-knew you were going to say that
+00:09:44,700 --> 00:09:44,746
+[laughs].
 
-190
-00:09:45,891 --> 00:09:47,036
-I
+189
+00:09:44,746 --> 00:09:47,037
+Dan: As soon as I said that, I
+knew you were gonna say that. I
 
 191
-00:09:47,037 --> 00:09:47,486
-did not
+00:09:47,037 --> 00:09:49,500
+did not ... fire ... Bekah.
 
 192
-00:09:48,386 --> 00:09:52,346
-Bekah: fire. My kids got sent
-home from school and then I came
+00:09:49,500 --> 00:09:51,700
+Bekah: You did. My kids got sent
+home from school, and then I
 
 193
-00:09:52,346 --> 00:09:54,716
-home and Dan was like, sorry,
-you're fired. Good luck.
+00:09:51,700 --> 00:09:54,716
+came home, and Dan was like,
+"Sorry, you're fired. Good luck
 
 194
-00:09:58,736 --> 00:10:01,248
-Dan: I mean, sometimes you have
-to fire. I didn't fire you.
+00:09:54,716 --> 00:09:55,000
+[laughs]."
+
+194
+00:09:57,300 --> 00:10:01,248
+Dan: Listen. I mean, sometimes
+you have to fire peep- people
 
 195
 00:10:01,248 --> 00:10:03,760
-Okay.
+[laughs]. I didn't fire you,
+o-okay?
 
 196
 00:10:03,761 --> 00:10:07,201
-You were a contractor, so I just
-stopped paying you and you
+You were a contractor, and so, I
+just stopped paying you, and you
 
 197
-00:10:07,211 --> 00:10:12,101
-stopped doing work. You're the
-worst. In my defense, I
+00:10:07,211 --> 00:10:08,000
+stopped doing work [laughs].
 
 198
-00:10:12,101 --> 00:10:15,522
-didn't have any money to pay you
-with. I didn't
+00:10:09,000 --> 00:10:10,000
+Bekah: You're the worst
+[laughs].
+
+198
+00:10:10,500 --> 00:10:13,700
+Dan: In my defense, I didn't
+have any money to pay you with
 
 199
-00:10:15,522 --> 00:10:16,756
-Bekah: have any work for you to
-do all right. Five minutes.
+00:10:13,700 --> 00:10:14,000
+[all laugh]. So --
 
 200
-00:10:16,756 --> 00:10:17,990
+00:10:14,500 --> 00:10:15,500
+Bekah: It will get so --
+
+199
+00:10:15,000 --> 00:10:16,756
+Dan: I didn't have any work for
+you to do.
+
+200
+00:10:16,756 --> 00:10:18,491
+Bekah: All right. Fine. Fine.
 Fine.
 
 201
-00:10:18,491 --> 00:10:24,402
+00:10:18,491 --> 00:10:21,700
 I'll be fair. It was pandemic.
-And there was no work. So he
+And there was no [laughs] work.
 
 202
-00:10:24,491 --> 00:10:26,022
-fired me on accident.
+00:10:21,700 --> 00:10:26,500
+So, he fired me on accident,
+apparently.
 
 203
-00:10:26,022 --> 00:10:27,462
-Dan: Apparently Nick knew you're
-going to say that as well.
+00:10:26,500 --> 00:10:27,462
+Dan: Yeah. Nick knew you're
+gonna say that as well.
 
 204
-00:10:27,462 --> 00:10:28,902
-You're
-
-205
-00:10:28,902 --> 00:10:29,892
-becoming predictable,
+00:10:27,462 --> 00:10:29,892
+You're becoming predictable.
 
 206
-00:10:31,601 --> 00:10:34,001
-Bekah: but I feel like we've had
-a lot of new members that might
+00:10:31,601 --> 00:10:33,500
+Bekah: [Laughs] But I feel like
+we've had a lot of new members
 
 207
-00:10:34,241 --> 00:10:37,001
-not have known that you fired me
-many times ago.
+00:10:33,500 --> 00:10:36,500
+that might not have known that
+you fired me many times
+
+208
+00:10:36,500 --> 00:10:37,001
+ago [laughs].
 
 208
 00:10:39,731 --> 00:10:45,432
-Dan: So, any way. Yes.
-So I don't know about you,
+Dan: So, anyway, yes.
+So, I don't know about you,
 
 209
-00:10:45,432 --> 00:10:48,252
-Bekah. I spent a lot of time.
-I'm like, okay. So what do I
+00:10:45,432 --> 00:10:50,500
+Bekah. I spent a lot of time,
+like, I'm like, "Okay. So, what
 
 210
-00:10:48,252 --> 00:10:51,072
-wear
+00:10:50,500 --> 00:10:51,300
+do I wear when
 
 211
-00:10:51,072 --> 00:10:54,011
-when I meet a person for the
-first time that I've like worked
+00:10:51,300 --> 00:10:54,011
+I meet a person for the first
+time, that I've, like, worked
 
 212
 00:10:54,011 --> 00:10:56,682
-closely with for three years,
-obviously virtual, probably
+closely with for three years?"
+Obviously, Virtual Coffee
 
 213
-00:10:56,682 --> 00:11:01,481
-stuff. I wore the t-shirt and
-the hoodie. I just wear
+00:10:56,682 --> 00:11:00,700
+stuff. I -- Bekah w-wore the
+t-shirt and the hoodie. I- I
 
 214
-00:11:01,572 --> 00:11:01,741
-Bekah: the
+00:11:00,700 --> 00:11:01,741
+just wear those --
+
+214
+00:11:01,741 --> 00:11:02,412
+Bekah: I understood the
+assignment.
 
 215
-00:11:02,412 --> 00:11:04,721
-Dan: assignment. Yeah. Well, we
+00:11:02,500 --> 00:11:04,721
+Dan: Yeah. Well, we
 didn't talk about it ahead of
 
 216
-00:11:04,721 --> 00:11:08,772
-time. I almost like texted you.
-I almost asked you and I should
+00:11:04,721 --> 00:11:07,300
+times. I almost, like, texted
+you. I almost, like, I almost
+
+217
+00:11:07,300 --> 00:11:08,772
+asked you, and I
 
 217
 00:11:08,772 --> 00:11:10,751
-have, because then we could have
-just been totally,
+should have. Because then we
+could have just been totally,
+
+219
+00:11:10,751 --> 00:11:11,000
+you know?
 
 218
-00:11:10,841 --> 00:11:13,152
-Bekah: you know, oh, wait, Arjun
-joined and wants to know who
+00:11:11,000 --> 00:11:13,152
+Bekah: Oh, wait. Arjun joined
+and wants to know who
 
 219
 00:11:13,152 --> 00:11:14,532
-fired me. Dan fired
+fired me. Dan fired me [laughs].
 
 220
-00:11:14,532 --> 00:11:21,011
-Dan: me. No, I did not fire you.
-I hate this. I'm shutting this
+00:11:14,532 --> 00:11:20,300
+Dan: No, I did not fire you [all
+laugh]. I hate this. I'm
 
 221
-00:11:21,011 --> 00:11:21,491
-stream down,
+00:11:20,300 --> 00:11:21,491
+shutting this stream down.
+
+222
+00:11:21,491 --> 00:11:24,131
+Bekah: No, wait. Yeah,
+[inaudible] [laughs].
 
 222
 00:11:24,131 --> 00:11:27,731
-Bekah: so, okay. So maybe let's
+So, okay. So maybe let's
 go back a little bit so I can
 
 223
 00:11:27,731 --> 00:11:31,182
 tell the full story and give Dan
-the credit that he is owed.
+the credit that he is owned.
 
 224
 00:11:31,211 --> 00:11:34,422
 I'm a career changer. I spent 10
-years teaching college, English,
+years teaching college English,
 
 225
 00:11:34,782 --> 00:11:38,922
@@ -1259,17 +1307,34 @@ and I went to bootcamp. And when
 I graduated, I put out a tweet
 
 226
-00:11:38,922 --> 00:11:42,761
+00:11:38,922 --> 00:11:43,000
 saying that I was looking for a
-job and Dan responded
+job. And Dan responded, and
 
 227
-00:11:46,312 --> 00:11:49,062
-Dan: not really, but seriously.
+00:11:43,000 --> 00:11:43,500
+hired me.
+
+228
+00:11:43,500 --. 00:11:46,000
+Dan: [Inaudible]. Not really.
+
+229
+00:11:46,000 --> 00:11:46,300
+Bekah: Yeah.
+
+227
+00:11:46,500 --> 00:11:50,300
+Dan: Not really, but ...
+seriously [laughs]. No, just
+
+228
+00:11:50,300 --. 00:11:50,500
+kidding [all laugh].
 
 228
 00:11:53,682 --> 00:11:56,321
-Bekah: So I did not. I
+Bekah: So, I did not -- I
 didn't take any coding tests or
 
 229
@@ -1278,7 +1343,7 @@ have to
 
 230
 00:11:58,961 --> 00:12:03,201
-do any. Strange problems that
+do any strange problems that
 make no difference in the world.
 
 231
@@ -1287,37 +1352,65 @@ And so, we worked together
 until the pandemic hit and then
 
 232
-00:12:09,231 --> 00:12:12,172
-everything shut down. So, yeah.
-So then
+00:12:09,231 --> 00:12:10,300
+everything shut down. So-
+
+233
+00:12:10,300 --> 00:12:10,500
+Dan: Yeah.
+
+234
+00:12:11,000 --> 00:12:11,500
+Bekah: So, Dan --
+
+235
+00:12:11,700 --> 00:12:12,300
+Dan: And I --
+
+236
+00:12:12,300 --> 00:12:13,000
+Bekah: I joked [laughs] --
 
 233
 00:12:13,251 --> 00:12:16,131
-Dan: as soon as I had worked
-coming back in that you had
+Dan: As soon as I had work
+coming back in, you had
 
 234
-00:12:16,131 --> 00:12:21,171
-worked coming back in to, you
-never say thank you. Yeah,
+00:12:16,131 --> 00:12:17,500
+work coming back in too.
 
 235
-00:12:21,171 --> 00:12:26,211
-it
+00:12:17,500 --> 00:12:17,700
+Bekah: Yeah.
 
 236
-00:12:26,211 --> 00:12:27,351
-was a re it was a rough summer.
+00:12:17,700 --> 00:12:19,500
+Dan: Cuz you never ... say --
 
 237
-00:12:27,381 --> 00:12:29,392
-Bekah: It was a weird summer. It
-was really rough. And that's how
+00:12:19,500 --> 00:12:20,700
+Bekah: He- he rehired me [laughs].
+
+238
+00:12:20,700 --> 00:12:26,211
+Dan: Oh, okay, thank you. Thank
+you [all laugh]. Well, yeah. It
+
+236
+00:12:26,211 --> 00:12:27,700
+was ro- it was a rough summer.
+It was a weird summer.
+
+237
+00:12:28,000 --> 00:12:29,392
+Bekah: That was really rough.
+And that's how
 
 238
 00:12:29,392 --> 00:12:31,191
-Virtual Coffee started too,
-because I was getting signed
+Virtual Coffee started too.
+Because I was getting assigned
 
 239
 00:12:31,191 --> 00:12:32,990
@@ -1326,81 +1419,113 @@ with
 240
 00:12:32,991 --> 00:12:37,491
 interviews with kids at home and
-trying to figure out like what
+trying to figure out, like, what
 
 241
-00:12:37,491 --> 00:12:40,431
-life was like. And then I put
-out this week, does anybody want
+00:12:37,491 --> 00:12:42,700
+life was like [chuckles]. And
+then, I put out a tweet, "Does
 
 242
-00:12:40,431 --> 00:12:43,371
-to
+00:12:42,700 --> 00:12:43,371
+anybody wanna
 
 243
-00:12:43,371 --> 00:12:45,831
-meet up for Virtual Coffee? And
-we just kept going with it. And,
+00:12:43,371 --> 00:12:46,000
+meet up for Virtual Coffee?" And
+we just kept going with it. And-
 
 244
-00:12:46,341 --> 00:12:49,236
-and somewhere along the line I
-pulled Dan in to cause he owed
+00:12:46,341 --> 00:12:50,000
+and somewhere along the line, I
+pulled Dan in too [chuckles]?
 
 245
-00:12:49,236 --> 00:12:52,131
-me
+00:12:50,000 --> 00:12:50,300
+Dan: Yeah.
+
+245
+00:12:51,000 --> 00:12:53,000
+Bekah: Cuz he owed me for
+firing me [laughs].
 
 246
-00:12:52,131 --> 00:12:52,942
-for firing me.
+00:12:53,000 --> 00:12:59,397
+Dan: Oh, gosh [chuckles].
+Alright. Alright.
 
 247
 00:12:59,397 --> 00:13:05,096
-Dan: So here's the one thing I'm
-so used to, like talking to
+So, here's the one thing. I'm-
+I'm so used to, like, talking to
 
 248
 00:13:05,096 --> 00:13:07,197
-you on zoom, we're sitting right
+you on Zoom. We're sitting right
 next to each other, but we have
 
 249
 00:13:07,197 --> 00:13:11,547
-the like zoom monitor on the
-screen. And so I have been like
+the, like, Zoom monitor on the
+screen. And so, I have been like
 
 250
-00:13:11,547 --> 00:13:12,852
-looking at, I keep looking at
-you on the screen instead of,
+00:13:11,547 --> 00:13:13,300
+looking at -- I keep looking at
+you on the screen instead of-
 
 251
-00:13:12,852 --> 00:13:14,157
-instead
+00:13:13,300 --> 00:13:14,700
+instead of, like, you next to
+me.
 
 252
-00:13:14,157 --> 00:13:15,626
-of like you next to me, I don't
-even
+00:13:14,700 --> 00:13:15,000
+Bekah: Yes.
+
+252
+00:13:15,000 --> 00:13:15,626
+Dan: I don't even understand.
 
 253
-00:13:15,626 --> 00:13:16,047
-Bekah: understand.
+00:13:15,626 --> 00:13:17,000
+Bekah: Yeah. I'm not really sure-
+
+254
+00:13:16,500 --> 00:13:17,700
+Dan: It's more the -- I don't
+understand it.
+
+255
+00:13:17,000 --> 00:13:18,700
+Bekah: -how's the deal. Am I
+suppose to look at you when I
+
+256
+00:13:18,700 --> 00:13:19,346
+talk to you?
 
 254
 00:13:19,346 --> 00:13:20,576
-Dan: Right. Exactly. Yeah.
-Right. Do I look to camera?
+Dan: No. Right. Exactly. Yeah,
+right. Do I look to camera? Do
 
 255
 00:13:20,576 --> 00:13:21,806
-Yeah. No,
+you -- yeah. No,
 
 256
 00:13:21,807 --> 00:13:25,677
 it's weird. Good, weird. But
-it's, it's weird, you know?
+it's- it's weird, you know?
+
+257
+00:13:25,677 --> 00:13:26,000
+Bekah: Mm-hmm.
+
+258
+00:13:26,000 --> 00:13:26,700
+Dan: [Inaudible]. Yeah.
 
 257
 00:13:27,567 --> 00:13:31,091
@@ -1408,21 +1533,46 @@ Bekah: Yeah. Okay. Let's see.
 Let me look at this chat.
 
 258
-00:13:31,091 --> 00:13:34,615
-Yes,
+00:13:34,000 --> 00:13:34,615
+[Chuckles] Yes,
 
 259
-00:13:34,647 --> 00:13:37,797
-Nick. Exactly. Dan responded.
-I'm looking for someone to fire
+00:13:34,647 --> 00:13:37,500
+Nick. Exactly. Dan responded,
+"I'm looking for someone to fire
 
 260
-00:13:37,797 --> 00:13:40,447
-eventually. Yes, I am totally
+00:13:37,500 --> 00:13:37,797
+eventually."
 
 261
-00:13:41,366 --> 00:13:42,297
-Dan: wired eventually.
+00:13:37,797 --> 00:13:38,700
+Dan: It was really just the
+power of truth.
+
+262
+00:13:38,300 --> 00:13:39,700
+Bekah: I was like, yeah. I am
+totally-
+
+263
+00:13:39,000 --> 00:13:41,700
+Dan: Man. That's- that's -- all
+of work -- all of our work are-
+
+264
+00:13:40,000 --> 00:13:42,000
+Bekah: -here for being fired
+eventually [laughs].
+
+265
+00:13:41,700 --> 00:13:42,500
+Dan: -out of life. Yeah.
+
+266
+00:13:43,500 --> 00:13:46,300
+Just a power to fire somebody,
+and then [inaudible].
 
 262
 00:13:45,626 --> 00:13:47,051
@@ -1436,17 +1586,21 @@ don't
 264
 00:13:48,476 --> 00:13:50,486
 know if Dan remembers it, but I
-remember,
+remember --
 
 265
-00:13:51,326 --> 00:13:55,706
-Dan: I mean, I didn't know
-what I was doing either. I mean,
+00:13:50,486 --> 00:13:54,500
+Dan: I did. Yeah. I mean, I
+didn't know what I was doing
+
+266
+00:13:54,500 --> 00:13:55,706
+either. It was -- I mean,
 
 266
 00:13:55,706 --> 00:13:57,776
-this is the first time I ever,
-and to be clear, like you
+this is the first time I ever --
+and to be clear, like, you
 
 267
 00:13:57,776 --> 00:13:59,846
@@ -1454,22 +1608,18 @@ weren't
 
 268
 00:13:59,846 --> 00:14:03,506
-an employee, so, you know, my
+an employee, so, you know? My
 whole thing was contractor, you
 
 269
-00:14:03,506 --> 00:14:04,946
-know, cause I'm a contractor
-too, but, yeah, I'd never
-
-270
-00:14:04,946 --> 00:14:06,386
-done
+00:14:03,506 --> 00:14:06,386
+know? Cuz I'm a contractor
+too, But, yeah. I'd never done
 
 271
 00:14:06,386 --> 00:14:08,576
 that before. And like, I really
-jumped into like very ADHD
+jumped into, like, very ADHD
 
 272
 00:14:08,576 --> 00:14:10,766
@@ -1477,7 +1627,7 @@ style,
 
 273
 00:14:10,767 --> 00:14:16,407
-like no real plan, no real, you
+like, no real plan, no real, you
 know, guidelines for myself or
 
 274
@@ -1487,269 +1637,430 @@ like that. And it worked out
 
 275
 00:14:18,266 --> 00:14:20,125
-very
+very well.
 
 276
-00:14:20,126 --> 00:14:27,267
-well, but, yeah, it was, it
-was, it was, it was fun.
+00:14:20,125 --> 00:14:22,000
+Bekah: It did! It worked out
+really well.
+
+276
+00:14:22,000 --> 00:14:27,267
+Dan: But ... yeah, I dunno. It
+was- it was- it was fun.
 
 277
 00:14:28,317 --> 00:14:31,772
-Haven't missed any, you
-know, I
+I'm -- I've been missing, you
+know, Bekah. You gotta ... I
 
 278
-00:14:31,772 --> 00:14:32,042
-Bekah: dunno.
+00:14:31,772 --> 00:14:32,000
+dunno.
+
+278
+00:14:32,000 --> 00:14:32,700
+Bekah: I fired Dan.
 
 279
-00:14:35,522 --> 00:14:41,371
-Dan: Yeah. So, you know,
-with like insurance, I've heard
+00:14:32,700 --> 00:14:33,300
+Dan: I was gonna say-
 
 280
-00:14:41,371 --> 00:14:41,611
-is
+00:14:33,000 --> 00:14:34,000
+Bekah: And I got a
+new job [laughs].
 
 281
-00:14:41,611 --> 00:14:44,322
-Bekah: a good thing to know.
-Insurance is nice. It's useful.
+00:14:33,500 --> 00:14:34,300
+Dan: -you got a job. Yeah.
+
+279
+00:14:35,522 --> 00:14:40,000
+Yeah. So, you know, with, like,
+insurance-
+
+00:14:40,000 --> 00:14:40,300
+Bekah: Yeah.
+
+280
+00:14:40,500 --> 00:14:42,500
+Dan: -I've heard is a good thing
+to have.
+
+281
+00:14:42,500 --> 00:14:44,322
+Bekah: Insurance is nice. It's
+useful.
 
 282
-00:14:46,111 --> 00:14:51,692
-Didn't have that for awhile. So,
-yeah. So I've been working a new
+00:14:44,322 --> 00:14:44,700
+Dan: So, you know --
+
+282
+00:14:46,111 --> 00:14:50,000
+Bekah: Didn't have that for
+awhile [all chuckle]. So, yeah.
+
+283
+00:14:50,000 --> 00:14:51,692
+So, I've been working a new
 
 283
 00:14:51,692 --> 00:14:55,892
 full-time job, and Dan has
-been,
+been --
 
 284
 00:14:57,361 --> 00:15:01,412
-Dan: thank you. If I didn't fire
-you there'll be no Virtual
+Dan: Yes. Ayu, thank you. If I
+didn't fire you, there'll be no
 
 285
-00:15:01,412 --> 00:15:02,912
-Coffee. I didn't fire you
+00:15:01,412 --> 00:15:04,500
+Virtual Coffee. I didn't fire
+you. God! I got tricked!
 
 286
-00:15:10,802 --> 00:15:12,272
-Bekah: so I can play it over and
-over.
+00:15:03,500 --> 00:15:05,500
+Bekah: [Laughs] He did it.
+Somebody-
+
+287
+00:15:05,500 --> 00:15:06,000
+Dan: Ooh, no.
+
+288
+00:15:06,000 --> 00:15:06,700
+Bekah: -please grab that.
+
+289
+00:15:06,700 --> 00:15:08,000
+Dan: No. We're shutting this
+whole thing now.
+
+290
+00:15:07,000 --> 00:15:08,000
+Bekah: Grab that from this
+video-
+
+291
+00:15:09,000 --> 00:15:10,000
+Dan: We're shutting it down.
+
+292
+00:15:10,500 --> 00:15:13,000
+Bekah: -so I can play it over
+and over [laughs].
 
 287
 00:15:14,412 --> 00:15:18,192
-Dan: I blamed melts, honestly,
-for that, for that one, we went
+Dan: I blamed Melts, honestly,
+for that- for that one. We went
 
 288
-00:15:18,192 --> 00:15:20,531
-to a mill in here in Lakewood
-and it's, I, we walked past the
+00:15:18,192 --> 00:15:21,700
+to Melt in here, in Lakewood.
+And there, it's -- I -- we
 
 289
-00:15:20,531 --> 00:15:22,870
-first
+00:15:21,700 --> 00:15:22,870
+walked past -- the first
 
 290
 00:15:22,871 --> 00:15:25,841
-place. I wanted to go found out,
+place I wanted to go, found out
 close for lunch on the weekdays,
 
 291
 00:15:26,022 --> 00:15:29,142
 which I didn't know. But as
-we were walking past Milt, I was
+we were walking past Melt, I was
 
 292
 00:15:29,142 --> 00:15:31,751
-like, this place makes you want
-to go take a nap after like,
+like, this place makes you wanna
+go take a nap after, like,
 
 293
-00:15:31,782 --> 00:15:34,212
-after. And it's, it's true.
-Yeah. I mean the two years
+00:15:31,782 --> 00:15:32,000
+after.
 
 294
-00:15:34,212 --> 00:15:36,642
-probably
+00:15:32,700 --> 00:15:33,000
+Bekah: Mm-hmm.
+
+295
+00:15:33,000 --> 00:15:34,000
+Dan: And it's- it's true.
+
+296
+00:15:34,000 --> 00:15:35,000
+Bekah: Can confirm.
+
+294
+00:15:35,000 --> 00:15:36,642
+Dan: Yeah. I mean, the two beers
+probably-
 
 295
 00:15:37,991 --> 00:15:39,491
-probably didn't help that
-either. But, I blame, yeah.
+-probably not bad either. But,
+I blame, yeah.
 
 296
 00:15:39,491 --> 00:15:40,991
-I blame
+I blame- I blame
 
 297
 00:15:41,471 --> 00:15:45,162
-that on that and the mental
-lapse. But once you stand from
+that on that- on that mental
+lapse. But I want to stand firm
 
 298
 00:15:45,162 --> 00:15:46,451
-that, I did not fire anybody.
+that I did not fire anybody.
 
 299
 00:15:47,201 --> 00:15:49,991
 Bekah: I mean, what is your
-definition of fire? Okay. He was
+definition of fire, okay? He was
 
 300
 00:15:49,991 --> 00:15:54,131
-like, I'm no longer going to
+like, "I'm no longer going to
 employ you or give you work or
 
 301
-00:15:54,131 --> 00:16:04,961
-money. So anybody out there
-please let me know. So now he's
+00:15:54,131 --> 00:15:58,000
+money." So, anybody out there
+please let me know [laughs].
 
 302
-00:16:04,961 --> 00:16:07,961
-roped into Virtual Coffee
-forever.
+00:16:01,000 --> 00:16:02,000
+Dan: Whatever.
+
+302
+00:16:03,500 --> 00:16:06,500
+Bekah: So now, he's roped into
+Virtual Coffee-
 
 303
-00:16:11,981 --> 00:16:18,861
-Dan: Anyway. Let's go back to, I
-was saying that I was right and
+00:16:06,500 --> 00:16:07,000
+Dan: Oh, god.
 
 304
-00:16:21,412 --> 00:16:23,662
-that everything that I did was
-good. I'm pretty sure that's
+00:16:07,000 --> 00:16:07,961
+Bekah: -forever [laughs].
+
+303
+00:16:09,000 --> 00:16:16,300
+Dan: Oh, man. Anyway, let's go
+back to Ayu was saying that I
+
+304
+00:16:16,300 --> 00:16:18,861
+was right. And --
 
 305
-00:16:23,662 --> 00:16:25,912
-what
+00:16:18,861 --> 00:16:20,500
+Bekah: I don't think that's what
+Ayu said, okay [chuckles]?
+
+304
+00:16:20,500 --> 00:16:22,300
+Dan: Yeah, yeah. Well, that-
+that everything that I did was
+
+305
+00:16:22,300 --> 00:16:22,700
+good.
 
 306
-00:16:25,912 --> 00:16:26,451
-she said.
+00:16:22,700 --> 00:16:25,000 
+Bekah: She -- 100% did not say
+that.
+
+305
+00:16:24,500 --> 00:16:26,451
+Dan: Yeah, no. I'm pretty sure
+that's what she said. And --
+
+306
+00:16:26,451 --> 00:16:26,700
+Bekah: She did not!
 
 307
-00:16:29,211 --> 00:16:31,341
-Bekah: Well, Dan, it sucks that
-you fired back and that was
+00:16:27,500 --> 00:16:30,000
+Dan: No, I tried to scroll.
+We can't- we can't scroll back.
 
 308
-00:16:31,341 --> 00:16:34,236
-pretty awful, but at least we
-got Virtual Coffee out of it and
+00:16:30,000 --> 00:16:31,000
+That's -- we can't [chuckles]
+--
+
+307
+00:16:28,000 --> 00:16:31,341
+Bekah: She's like, "Dan, it
+sucks that you fired Bekah and
+
+308
+00:16:31,341 --> 00:16:33,500
+that was pretty awful. But at
+least we got Virtual Coffee out
 
 309
-00:16:34,236 --> 00:16:37,131
-you
+00:16:33,500 --> 00:16:34,000
+of it [laughs]."
 
 310
-00:16:37,131 --> 00:16:42,456
-can fire me any day. I don't
-even know what that means.
+00:16:35,000 --> 00:16:37,500
+Dan: We can't scroll back and
+see what she says. [Inaudible].
+
+310
+00:16:35,500 --> 00:16:40,000
+Bekah: Nick tells, "Dan- Dan,
+you can fire me any day [all
 
 311
-00:16:42,456 --> 00:16:47,781
-Sometimes I
+00:16:40,000 --> 00:16:42,456
+laugh]." I don't even know what
+that means [laughs].
+
+312
+00:16:45,000 --> 00:16:45,700
+Dan: Ooh, Nick.
+
+311
+00:16:47,000 --> 00:16:47,781
+Bekah: Sometimes, I,
 
 312
 00:16:47,782 --> 00:16:50,241
-like very frequently will spit
+like, very frequently will spit
 out water when I drink it. So I
 
 313
 00:16:50,241 --> 00:16:53,751
 need to try very hard to not
-drink and laugh at
+drink and laugh at the same
 
 314
-00:16:53,751 --> 00:16:59,966
-Dan: the same time. Yeah.
-Somebody's episode. That was a
+00:16:53,751 --> 00:16:54,000
+time.
+
+314
+00:16:54,000 --> 00:16:59,966
+Dan:  Hmm, wait. Who's ... Yeah.Somebody's episode, that was a
 
 315
-00:16:59,966 --> 00:17:02,366
-really good one to that. Oh
-yeah. I watched you do it. I
+00:16:59,966 --> 00:17:00,500
+really good one of that.
 
 316
-00:17:02,366 --> 00:17:04,766
-watched
+00:17:00,500 --> 00:17:02,366
+Bekah: Oh, oh, it's Helen!
+
+316
+00:17:02,366 --> 00:17:02,700
+Dan: Oh yeah, Helen.
 
 317
-00:17:04,767 --> 00:17:06,027
-you swallow or like, you know,
-start drink water. And then
+00:17:02,700 --> 00:17:03,000
+Bekah: Yeah.
 
 318
-00:17:06,027 --> 00:17:07,287
-Helen
+00:17:03,000 --> 00:17:04,766
+Dan: Yeah. Yeah, I watched you
+do it. I watched you swallow or,
+
+317
+00:17:04,767 --> 00:17:07,287
+like, you know, start to drink
+water. And then Helen
 
 319
-00:17:07,287 --> 00:17:12,537
-said something hilarious and,
-yeah, we, both have a
+00:17:07,287 --> 00:17:09,500
+said something hilarious, and,
+yeah.
 
 320
-00:17:12,537 --> 00:17:17,787
-problem
+00:17:09,500 --> 00:17:10,500 
+Bekah: I didn't mute myself.
 
 321
-00:17:17,787 --> 00:17:20,517
-with, sometimes we, you know, I
+00:17:10,500 --> 00:17:11,300
+Dan: I was like, "Oh, please."
+
+322
+00:17:10,700 --> 00:17:13,000
+Bekah: I was like choking for
+five minutes [laughs].
+
+321
+00:17:14,000 --> 00:17:18,000
+Dan: We -- yeah, Bekah and I
+both have a- a problem with --
+
+321
+00:17:18,000 --> 00:17:20,517
+sometimes we, you know, you -- I
 don't know if you could get this
 
 322
 00:17:20,517 --> 00:17:23,876
-in zoom where you, why you're
-not like making, I kind of take
+in Zoom, where you ... you --
+you're not, like, making eye
 
 323
 00:17:23,876 --> 00:17:26,727
-what's a real person, you know,
-but, but like, you almost can,
+contact with a real person, you
+know? But- but like, you almost
 
 324
-00:17:26,727 --> 00:17:28,017
-like sometimes you know, where,
-like, you know, you're looking
+00:17:26,727 --> 00:17:26,500
+can, like-
 
 325
-00:17:28,017 --> 00:17:29,307
-at
+00:17:26,500 -->00:17:26,700
+Bekah: Yeah.
 
 326
-00:17:29,307 --> 00:17:30,177
-that person that, you know,
-they're looking at you, you
+00:17:26,600 --> 00:17:28,
+Dan: -in Zoom, sometimes, you
+know? Where, like, you know,
 
-327
-00:17:30,177 --> 00:17:31,047
-know,
+325
+00:17:28,500 --> 00:17:29,307
+you're looking at
+
+326
+00:17:29,307 --> 00:17:31,047
+that person, you know they're
+looking at you, you know?
 
 328
-00:17:31,616 --> 00:17:33,231
-and, you know, we've had
-some, we've had some meltdowns
+00:17:31,616 --> 00:17:34,000
+And, yeah. We've had some- we've
+had some meltdowns in the- in
 
 329
-00:17:33,231 --> 00:17:34,846
-in
+00:17:34,000 --> 00:17:36,000
+the past [all laugh].
 
 330
-00:17:34,846 --> 00:17:39,086
-the past. We try to keep it on
-the podcast, but there's been
+00:17:36,300 --> 00:17:38,500
+We try to keep it, you know,
+it's all on the podcast. But
 
 331
-00:17:39,086 --> 00:17:41,666
-some. There's been some moments.
+00:17:38,500 --> 00:17:41,666
+there's been some- there's been
+some- there's been some moments.
+
+---
 
 332
 00:17:42,477 --> 00:17:43,842

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -1,6 +1,6 @@
 1
 00:00:05,181 --> 00:00:07,370
-Dan: Hello, and welcome to a
+Dan Ott: Hello, and welcome to a
 special Kirk Day Bonus Episode
 
 2
@@ -9,7 +9,7 @@ of
 
 3
 00:00:09,560 --> 00:00:15,528
-the Virtual Coffee podcast. I'm
+the Virtual Coffee Podcast. I'm
 Dan and this is a podcast that
 
 4
@@ -110,12 +110,12 @@ thing and
 
 24
 00:01:21,496 --> 00:01:23,401
-Bekah: just so everybody knows,
-I just did the most amazing
+Bekah Hawrot Weigel: just so
+everybody knows, I just did the
 
 25
 00:01:23,401 --> 00:01:25,306
-intro
+most amazing intro
 
 26
 00:01:25,367 --> 00:01:26,266
@@ -180,12 +180,12 @@ date is?
 
 39
 00:02:05,027 --> 00:02:10,727
-Dan: Um, so was it just a year
+Dan: So was it just a year
 ago or a year ago today? Yes,
 
 40
 00:02:10,757 --> 00:02:16,481
-Kirk, um, had a tweet. Where he
+Kirk, had a tweet. Where he
 showed me that I should read
 
 41
@@ -214,12 +214,12 @@ it. I have ascended. And then,
 
 46
 00:02:37,662 --> 00:02:43,002
-um, very shortly after that, uh,
+very shortly after that,
 Missy Elliott responded, replied
 
 47
 00:02:43,002 --> 00:02:46,241
-on Twitter, um, actual Missy
+on Twitter, actual Missy
 Elliott, not, not a fake Missy
 
 48
@@ -230,7 +230,7 @@ like, yeah, she said, wow, I'm
 49
 00:02:50,592 --> 00:02:53,366
 humbly I'm. So humbly grateful,
-much love to y'all. And, um,
+much love to y'all. And,
 
 50
 00:02:53,366 --> 00:02:56,140
@@ -243,12 +243,12 @@ It was, it was really, really
 
 52
 00:02:59,981 --> 00:03:03,822
-awesome. And, uh, everybody saw
+awesome. And, everybody saw
 it and perks, you know, Twitter.
 
 53
 00:03:04,542 --> 00:03:08,442
-Uh, let's see what the, uh, It,
+Let's see what the, It,
 it Kirk's sweet, got a one
 
 54
@@ -257,7 +257,7 @@ it Kirk's sweet, got a one
 
 55
 00:03:12,342 --> 00:03:18,282
-retweets. Uh, and it's really
+retweets. And it's really
 good stuff.
 
 56
@@ -287,7 +287,7 @@ already loved Kirk. And this is
 61
 00:03:37,151 --> 00:03:40,122
 just a sort of celebration of,
-of, uh, the rest of the world.
+of, the rest of the world.
 
 62
 00:03:40,181 --> 00:03:41,801
@@ -304,7 +304,7 @@ story.
 
 65
 00:03:47,771 --> 00:03:49,691
-Dan: Um, I think that's a great
+Dan: I think that's a great
 idea. Do you want me to go
 
 66
@@ -332,13 +332,13 @@ time of. Virtual Coffee being,
 
 71
 00:04:03,146 --> 00:04:08,097
-uh, a little it's a little
+a little it's a little
 smaller, you know? And so we had
 
 72
 00:04:08,097 --> 00:04:12,161
-slack, we had, um, the coffees
-obviously. Um, but, and I'm not
+slack, we had, the coffees
+obviously. But, and I'm not
 
 73
 00:04:12,161 --> 00:04:16,225
@@ -371,7 +371,7 @@ festivals really like leading up
 79
 00:04:29,786 --> 00:04:32,431
 to October Fest that year. So it
-was two years ago. And, um,
+was two years ago. And,
 
 80
 00:04:32,431 --> 00:04:35,076
@@ -394,12 +394,12 @@ them
 84
 00:04:43,031 --> 00:04:47,201
 with virtual profit and all that
-stuff. And, um, I could just
+stuff. And, I could just
 
 85
 00:04:47,201 --> 00:04:49,062
 kinda wrote me in for
-Oktoberfest
+Hacktoberfest
 
 86
 00:04:49,182 --> 00:04:50,816
@@ -425,8 +425,8 @@ you offer to help,
 
 91
 00:04:58,661 --> 00:05:00,956
-Dan: you will. Uh, it's true.
-Um, yes, most people find that
+Dan: you will. It's true.
+Yes, most people find that
 
 92
 00:05:00,956 --> 00:05:03,251
@@ -434,7 +434,7 @@ out
 
 93
 00:05:03,252 --> 00:05:05,712
-about eventually. Um, but yeah,
+about eventually. But yeah,
 so Kirk was there too. Right.
 
 94
@@ -467,12 +467,12 @@ Bekah: name, you know?
 
 100
 00:05:27,672 --> 00:05:29,831
-Dan: And, uh, yeah. And then
+Dan: And, yeah. And then
 that, so that it was like that
 
 101
 00:05:29,831 --> 00:05:32,569
-September leading up to, uh,
+September leading up to,
 That October, it was a lot of
 
 102
@@ -510,7 +510,7 @@ doing all that stuff. And so I
 109
 00:05:45,357 --> 00:05:50,607
 would be up in the middle of the
-night. Uh, and Kirk was usually
+night. And Kirk was usually
 
 110
 00:05:50,607 --> 00:05:52,242
@@ -547,7 +547,7 @@ are going
 117
 00:06:04,497 --> 00:06:07,976
 to interact with Virtual Coffee
-and like how, uh, we need
+and like how, we need
 
 118
 00:06:08,307 --> 00:06:11,156
@@ -571,7 +571,7 @@ again, a lot of like respect for
 122
 00:06:16,947 --> 00:06:21,086
 him, you know, at the same time.
-So, um, so yeah, and then after
+So, so yeah, and then after
 
 123
 00:06:21,086 --> 00:06:23,906
@@ -591,7 +591,7 @@ the dimensions, you know, in, in
 126
 00:06:31,226 --> 00:06:34,916
 multiple dimensions, I'd say,
-uh, if we're gonna use MCU
+if we're gonna use MCU
 
 127
 00:06:35,807 --> 00:06:37,446
@@ -667,7 +667,7 @@ Coffee
 
 143
 00:07:19,286 --> 00:07:25,646
-and. I am really, um, like
+and. I am really, like
 nervous when I meet new people.
 
 144
@@ -697,7 +697,7 @@ who is this person that is
 149
 00:07:43,317 --> 00:07:47,127
 coming? I'm very nervous about
-them. Um, and then Kirk kept
+them. And then Kirk kept
 
 150
 00:07:47,127 --> 00:07:50,786
@@ -733,7 +733,7 @@ HEC
 
 157
 00:08:05,007 --> 00:08:10,766
-Tober Fest team and it was, um,
+Tober Fest team and it was,
 me Dan, Sarah, Brian, and Kirk.
 
 158
@@ -753,11 +753,11 @@ think about this for a second,
 161
 00:08:21,987 --> 00:08:29,156
 like you used to be probably
-shed. So Kirk was, uh, always
+shed. So Kirk was, always
 
 162
 00:08:29,156 --> 00:08:34,466
-doing a great job of, um, roping
+doing a great job of, roping
 us all back to having productive
 
 163
@@ -819,13 +819,13 @@ people through the documentation
 
 175
 00:09:04,636 --> 00:09:08,836
-became, um, something that was
+became, something that was
 like a change in my life, you
 
 176
 00:09:08,836 --> 00:09:12,541
 know, like no big deal, but
-that's all. Um, so all right,
+that's all. So all right,
 
 177
 00:09:12,541 --> 00:09:16,246
@@ -843,7 +843,7 @@ be my best friend ever
 
 180
 00:09:22,336 --> 00:09:27,047
-Dan: since. Yeah. Uh, so we just
+Dan: since. Yeah. So we just
 got a comment from David saying,
 
 181
@@ -924,7 +924,7 @@ stopped paying you and you
 197
 00:10:07,211 --> 00:10:12,101
 stopped doing work. You're the
-worst. Uh, in my defense, I
+worst. In my defense, I
 
 198
 00:10:12,101 --> 00:10:15,522
@@ -974,8 +974,8 @@ many times ago.
 
 208
 00:10:39,731 --> 00:10:45,432
-Dan: Um, so, uh, any way. Yes.
-Um, so I don't know about you,
+Dan: So, any way. Yes.
+So I don't know about you,
 
 209
 00:10:45,432 --> 00:10:48,252
@@ -1046,7 +1046,7 @@ go back a little bit so I can
 223
 00:11:27,731 --> 00:11:31,182
 tell the full story and give Dan
-the credit that he is owed. Um,
+the credit that he is owed.
 
 224
 00:11:31,211 --> 00:11:34,422
@@ -1069,7 +1069,7 @@ Dan: not really, but seriously.
 
 228
 00:11:53,682 --> 00:11:56,321
-Bekah: So I did not. Um, I
+Bekah: So I did not. I
 didn't take any coding tests or
 
 229
@@ -1083,7 +1083,7 @@ make no difference in the world.
 
 231
 00:12:03,591 --> 00:12:08,542
-And so, uh, we worked together
+And so, we worked together
 until the pandemic hit and then
 
 232
@@ -1099,7 +1099,7 @@ coming back in that you had
 234
 00:12:16,131 --> 00:12:21,171
 worked coming back in to, you
-never say thank you. Um, yeah,
+never say thank you. Yeah,
 
 235
 00:12:21,171 --> 00:12:26,211
@@ -1158,7 +1158,7 @@ for firing me.
 247
 00:12:59,397 --> 00:13:05,096
 Dan: So here's the one thing I'm
-so used to, uh, like talking to
+so used to, like talking to
 
 248
 00:13:05,096 --> 00:13:07,197
@@ -1199,13 +1199,13 @@ Yeah. No,
 
 256
 00:13:21,807 --> 00:13:25,677
-it's weird. Um, good, weird. But
+it's weird. Good, weird. But
 it's, it's weird, you know?
 
 257
 00:13:27,567 --> 00:13:31,091
 Bekah: Yeah. Okay. Let's see.
-Let me look at this chat. Um,
+Let me look at this chat.
 
 258
 00:13:31,091 --> 00:13:34,615
@@ -1240,7 +1240,7 @@ remember,
 
 265
 00:13:51,326 --> 00:13:55,706
-Dan: um, I mean, I didn't know
+Dan: I mean, I didn't know
 what I was doing either. I mean,
 
 266
@@ -1260,7 +1260,7 @@ whole thing was contractor, you
 269
 00:14:03,506 --> 00:14:04,946
 know, cause I'm a contractor
-too, but, uh, yeah, I'd never
+too, but, yeah, I'd never
 
 270
 00:14:04,946 --> 00:14:06,386
@@ -1291,13 +1291,13 @@ very
 
 276
 00:14:20,126 --> 00:14:27,267
-well, but, um, yeah, it was, it
-was, it was, it was fun. Um, uh,
+well, but, yeah, it was, it
+was, it was, it was fun.
 
 277
 00:14:28,317 --> 00:14:31,772
-haven't missed any, uh, you
-know, uh, I
+Haven't missed any, you
+know, I
 
 278
 00:14:31,772 --> 00:14:32,042
@@ -1305,7 +1305,7 @@ Bekah: dunno.
 
 279
 00:14:35,522 --> 00:14:41,371
-Dan: Uh, yeah. So, um, you know,
+Dan: Yeah. So, you know,
 with like insurance, I've heard
 
 280
@@ -1324,7 +1324,7 @@ yeah. So I've been working a new
 
 283
 00:14:51,692 --> 00:14:55,892
-full-time job, um, and Dan has
+full-time job, and Dan has
 been,
 
 284
@@ -1362,7 +1362,7 @@ close for lunch on the weekdays,
 
 291
 00:15:26,022 --> 00:15:29,142
-which I didn't know. Um, but as
+which I didn't know. But as
 we were walking past Milt, I was
 
 292
@@ -1382,7 +1382,7 @@ probably
 295
 00:15:37,991 --> 00:15:39,491
 probably didn't help that
-either. But, uh, I blame, yeah.
+either. But, I blame, yeah.
 
 296
 00:15:39,491 --> 00:15:40,991
@@ -1494,7 +1494,7 @@ Helen
 319
 00:17:07,287 --> 00:17:12,537
 said something hilarious and,
-uh, yeah, we, uh, both have a
+yeah, we, both have a
 
 320
 00:17:12,537 --> 00:17:17,787
@@ -1535,7 +1535,7 @@ know,
 
 328
 00:17:31,616 --> 00:17:33,231
-and, uh, you know, we've had
+and, you know, we've had
 some, we've had some meltdowns
 
 329
@@ -1599,7 +1599,7 @@ video we have of it, but like,
 
 342
 00:18:00,566 --> 00:18:02,786
-uh, we
+we
 
 343
 00:18:02,787 --> 00:18:05,727
@@ -1652,7 +1652,7 @@ main skills.
 
 353
 00:18:34,317 --> 00:18:38,231
-Bekah: Um, just checking out the
+Bekah: Just checking out the
 chat. Promoted to customer.
 
 354
@@ -1692,7 +1692,7 @@ I'm around people that I know or
 361
 00:19:11,612 --> 00:19:13,951
 people that I'm friends with
-and, um, I can often like find
+and, I can often like find
 
 362
 00:19:13,951 --> 00:19:16,290
@@ -1705,7 +1705,7 @@ energy. I think that extroverts
 364
 00:19:18,241 --> 00:19:24,692
 Dan: have, for me, it's, for me,
-it's um, sort of knowing exactly
+it's sort of knowing exactly
 
 365
 00:19:24,692 --> 00:19:28,862
@@ -1733,7 +1733,7 @@ Bekah: know,
 370
 00:19:38,771 --> 00:19:40,916
 Dan: can't you tell we did,
-like, we did like, uh, this is
+like, we did like, this is
 
 371
 00:19:40,916 --> 00:19:43,061
@@ -1741,8 +1741,8 @@ yeah.
 
 372
 00:19:43,092 --> 00:19:44,982
-Very polished, uh, you know,
-thing. No. Um, but what I mean
+Very polished, you know,
+thing. No. But what I mean
 
 373
 00:19:44,982 --> 00:19:46,872
@@ -1750,7 +1750,7 @@ is
 
 374
 00:19:46,872 --> 00:19:49,541
-like, uh, I know what socially
+like, I know what socially
 is expected of me in this
 
 375
@@ -1775,7 +1775,7 @@ a problem. Like I don't, I don't
 379
 00:20:02,832 --> 00:20:06,161
 get like, awkward like that,
-but, um, but when I go to like
+but, but when I go to like
 
 380
 00:20:06,161 --> 00:20:09,490
@@ -1854,7 +1854,7 @@ is those, those like situations,
 
 396
 00:20:39,672 --> 00:20:45,011
-uh, Where it's an unfamiliar
+Where it's an unfamiliar
 territory or like, you know, I
 
 397
@@ -1907,7 +1907,7 @@ tries very hard to be personal.
 
 407
 00:21:12,221 --> 00:21:16,362
-Um, but that was like, um, my
+But that was like, my
 worst nightmare talking to a
 
 408
@@ -1932,7 +1932,7 @@ just doesn't naturally, like, he
 412
 00:21:25,571 --> 00:21:29,382
 doesn't almost like impulsively,
-you know, but like, like, uh, in
+you know, but like, like, in
 
 413
 00:21:29,382 --> 00:21:32,172
@@ -1968,8 +1968,8 @@ mean? And like, but that's just
 
 420
 00:21:45,071 --> 00:21:48,101
-how he is, you know? Uh, yeah.
-Uh, somebody said something
+how he is, you know? Yeah.
+Somebody said something
 
 421
 00:21:48,101 --> 00:21:51,131
@@ -2126,7 +2126,7 @@ my natural state of.
 
 453
 00:23:23,136 --> 00:23:25,747
-Dan: I ended there. Yes. Um,
+Dan: I ended there. Yes.
 
 454
 00:23:26,497 --> 00:23:29,467
@@ -2146,11 +2146,11 @@ exciting
 457
 00:23:39,997 --> 00:23:48,156
 Dan: to Minnesota. Marie had to
-go um, yeah,
+go yeah,
 
 458
 00:23:49,017 --> 00:23:51,162
-Bekah: we should. Um, is, is
+Bekah: we should. Is, is
 Kirk around? Can we bring Kirk
 
 459
@@ -2159,7 +2159,7 @@ on?
 
 460
 00:23:54,326 --> 00:24:02,547
-Dan: I dunno, it is, uh, Kirk
+Dan: I dunno, it is, Kirk
 day, which is where we started.
 
 461
@@ -2183,7 +2183,7 @@ celebrity.
 
 465
 00:24:15,416 --> 00:24:20,027
-Dan: It'll be funny. Uh, because
+Dan: It'll be funny. Because
 once we get another person on
 
 466
@@ -2198,7 +2198,7 @@ work. What's word two people do
 
 468
 00:24:31,342 --> 00:24:31,761
-Kirk: that.
+Kirk Shillingford: that.
 
 469
 00:24:32,662 --> 00:24:37,192
@@ -2287,7 +2287,7 @@ to turn off the world, please
 487
 00:25:36,086 --> 00:25:38,396
 stand up. Yes. Oh my goodness.
-We definitely need to, um, find
+We definitely need to, find
 
 488
 00:25:38,396 --> 00:25:40,706
@@ -2318,7 +2318,7 @@ really
 494
 00:25:52,586 --> 00:25:56,457
 Bekah: all right. I'll tell my
-joke. Um, have you all one about
+joke. Have you all one about
 
 495
 00:25:56,457 --> 00:25:57,146
@@ -2516,7 +2516,7 @@ punchline at the end in
 537
 00:28:08,846 --> 00:28:20,656
 Dan: your oh, weird Kirk here.
-Um, okay. Well, according to
+Okay. Well, according to
 
 538
 00:28:20,656 --> 00:28:25,997
@@ -2525,7 +2525,7 @@ see, Kirk was not consulted at
 
 539
 00:28:25,997 --> 00:28:30,166
-all for any of this. Uh, that is
+all for any of this. That is
 true. I try not to consult Kirk
 
 540
@@ -2538,7 +2538,7 @@ Bekah: we need
 
 542
 00:28:36,767 --> 00:28:38,566
-Dan: right, exactly. Or, uh, you
+Dan: right, exactly. Or, you
 know, where he might have time
 
 543
@@ -2595,7 +2595,7 @@ that Dan fires
 
 554
 00:29:20,352 --> 00:29:24,001
-Dan: me. Um, how about a select
+Dan: me. How about a select
 button that just announces the
 
 555
@@ -2683,7 +2683,7 @@ mean, if that's all we have to
 
 573
 00:30:11,737 --> 00:30:15,247
-do, uh, you know, we can do
+do, you know, we can do
 AirPods or something, but like,
 
 574
@@ -2699,7 +2699,7 @@ is the first time I've ever. Sat
 576
 00:30:27,446 --> 00:30:31,047
 next to somebody and try to be
-beyond, uh,
+beyond,
 
 577
 00:30:31,166 --> 00:30:35,696
@@ -2717,13 +2717,13 @@ fucking room and do that like,
 
 580
 00:30:38,936 --> 00:30:42,146
-oh, sorry. Uh, I did not mean to
+oh, sorry. I did not mean to
 curse, but she made me have two
 
 581
 00:30:42,146 --> 00:30:44,756
 beers and she, you know, she
-forced me to do it and, um,
+forced me to do it and,
 
 582
 00:30:44,756 --> 00:30:47,366
@@ -2798,7 +2798,7 @@ your AirPods?
 
 597
 00:31:31,977 --> 00:31:34,647
-Dan: The, uh, that's as soon as
+Dan: The, that's as soon as
 I thought that that's where like
 
 598
@@ -2821,7 +2821,7 @@ well.
 
 602
 00:31:43,767 --> 00:31:50,156
-Um, there has to be some sort of
+There has to be some sort of
 like, I don't know. I feel like
 
 603
@@ -2915,7 +2915,7 @@ going
 622
 00:32:47,531 --> 00:32:51,056
 on here. I don't know where I
-fit in. Um, don't have any jokes
+fit in. Don't have any jokes
 
 623
 00:32:51,056 --> 00:32:54,581
@@ -3126,7 +3126,7 @@ day to like remind you to stop
 667
 00:35:29,217 --> 00:35:33,507
 and think like, oh, I am going
-to, um, tell this person that I
+to, tell this person that I
 
 668
 00:35:33,507 --> 00:35:35,862
@@ -3149,8 +3149,8 @@ Elliot day. We do
 
 672
 00:35:45,836 --> 00:35:49,137
-Kirk: love you. We love you. Uh,
-let's see, I wasn't prepared for
+Kirk: love you. We love you.
+Let's see, I wasn't prepared for
 
 673
 00:35:49,137 --> 00:35:49,706
@@ -3248,7 +3248,7 @@ passion live inside, less
 693
 00:37:08,967 --> 00:37:10,991
 Bekah: fire. My other origin
-story is not, uh, it's. It's
+story is not, it's. It's
 
 694
 00:37:10,991 --> 00:37:13,015
@@ -3256,7 +3256,7 @@ not,
 
 695
 00:37:13,077 --> 00:37:19,916
-um, it's rated PG 13 decoding.
+it's rated PG 13 decoding.
 
 696
 00:37:21,117 --> 00:37:26,657
@@ -3396,7 +3396,7 @@ tree
 
 726
 00:38:42,226 --> 00:38:45,606
-Dan: house. I laid, I went, uh,
+Dan: house. I laid, I went,
 To last week, when was I going?
 
 727
@@ -3475,7 +3475,7 @@ surprise to me, but it was cool.
 743
 00:39:24,266 --> 00:39:27,447
 And it made sense once I thought
-about it. So like lots of, uh,
+about it. So like lots of,
 
 744
 00:39:27,626 --> 00:39:30,056
@@ -3504,7 +3504,7 @@ little bike trailer, you know,
 749
 00:39:40,646 --> 00:39:44,831
 but they're just like fine out.
-Um, I went on. That's
+I went on. That's
 
 750
 00:39:44,831 --> 00:39:46,871
@@ -3517,7 +3517,7 @@ bikes,
 
 752
 00:39:49,061 --> 00:39:52,751
-um, there was like a massive
+there was like a massive
 upsurge in popularity with women
 
 753
@@ -3676,7 +3676,7 @@ cycling.
 
 786
 00:41:39,027 --> 00:41:42,476
-Bekah: Um, yes. Yeah, that's it.
+Bekah: Yes. Yeah, that's it.
 I don't know. I probably would
 
 787
@@ -3807,11 +3807,11 @@ reckon,
 813
 00:43:01,347 --> 00:43:06,356
 Dan: I like the part about sled
-riding is picking your spot. Uh,
+riding is picking your spot.
 
 814
 00:43:06,387 --> 00:43:09,356
-cause if you go where there's
+Cause if you go where there's
 like huge ramps or like, I don't
 
 815
@@ -3919,7 +3919,7 @@ somebody named, I got it
 837
 00:44:08,246 --> 00:44:10,586
 originally from bike riding,
-but, uh, that was, I don't know
+but, that was, I don't know
 
 838
 00:44:10,586 --> 00:44:12,926
@@ -3928,7 +3928,7 @@ what
 839
 00:44:12,927 --> 00:44:18,567
 all that stuff was with. Yeah.
-Like beg his daughters, uh, sent
+Like beg his daughters, sent
 
 840
 00:44:18,567 --> 00:44:23,202
@@ -3988,7 +3988,7 @@ pan Kirk's some pancakes that
 
 852
 00:44:50,561 --> 00:44:54,101
-looked like Kirk. Um, and then
+looked like Kirk. And then
 they argued over who would eat
 
 853
@@ -4037,7 +4037,7 @@ heartwarming, but also quite
 
 862
 00:45:33,222 --> 00:45:36,492
-strange. Um, I only know how to
+strange. I only know how to
 make pancakes from scratch, not
 
 863
@@ -4098,7 +4098,7 @@ like you made them do this.
 
 875
 00:46:11,981 --> 00:46:16,331
-Dan: I, uh, so we were talking,
+Dan: I, so we were talking,
 I mean, we wanted to hang out in
 
 876
@@ -4220,7 +4220,7 @@ you
 
 901
 00:47:39,867 --> 00:47:43,312
-hit the, uh, what's the what's
+hit the, what's the what's
 the perfect triangle. Equal
 
 902
@@ -4244,7 +4244,7 @@ full workout, then you get into
 906
 00:47:52,976 --> 00:47:55,181
 the 3d and you get some cubes
-and you know, you get some, uh,
+and you know, you get some,
 
 907
 00:47:55,181 --> 00:47:57,386
@@ -4272,7 +4272,7 @@ it's definitely that,
 
 912
 00:48:12,746 --> 00:48:15,927
-Dan: um, deadlift, deadlift,
+Dan: Deadlift, deadlift,
 Bekah would very easily. I mean,
 
 913
@@ -4357,7 +4357,7 @@ think Dan could crush me in,
 
 930
 00:49:02,911 --> 00:49:05,541
-Dan: um, I'm like for somebody
+Dan: I'm like for somebody
 who
 
 931
@@ -4593,7 +4593,7 @@ real
 980
 00:51:33,731 --> 00:51:37,302
 life, but I've seen them on
-YouTube. Uh, if you want some,
+YouTube. If you want some,
 
 981
 00:51:38,262 --> 00:51:40,722
@@ -4630,7 +4630,7 @@ that
 
 988
 00:51:52,632 --> 00:51:56,231
-moment. Um, but that's never
+moment. But that's never
 going to happen. You're
 
 989
@@ -4645,7 +4645,7 @@ gotta figure this
 991
 00:51:59,831 --> 00:52:08,952
 Bekah: out. Kindness
-documentation. Um, well, I don't
+documentation. Well, I don't
 
 992
 00:52:08,952 --> 00:52:12,882
@@ -4802,7 +4802,7 @@ thing we used to use to make
 1025
 00:54:13,827 --> 00:54:19,376
 websites? My professor in
-university used it. Um, it flips
+university used it. It flips
 
 1026
 00:54:19,436 --> 00:54:20,817
@@ -4897,12 +4897,12 @@ Dreamweaver fireworks, and then
 1046
 00:55:14,367 --> 00:55:17,936
 like flash, if you do a flash
-and, uh, there was another one
+and, there was another one
 
 1047
 00:55:17,936 --> 00:55:19,466
 that I didn't use very much,
-like a more, uh, designing one,
+like a more, designing one,
 
 1048
 00:55:19,466 --> 00:55:20,996
@@ -4910,7 +4910,7 @@ but,
 
 1049
 00:55:21,387 --> 00:55:22,857
-um, yeah, I wasn't doing more
+yeah, I wasn't doing more
 than farmers and like
 
 1050
@@ -4919,8 +4919,8 @@ Dreamweaver
 
 1051
 00:55:24,327 --> 00:55:26,381
-was actually really good. Uh,
-even not using the like
+was actually really good.
+Even not using the like
 
 1052
 00:55:26,381 --> 00:55:28,435
@@ -5015,7 +5015,7 @@ Dan: it.
 
 1072
 00:56:13,146 --> 00:56:14,901
-Kirk: Um, just to say, Jeff,
+Kirk: Just to say, Jeff,
 Jeff in the chat was like, do
 
 1073
@@ -5034,7 +5034,7 @@ problems
 1076
 00:56:21,487 --> 00:56:29,257
 here. That's not, that's not
-better. Um, yeah. Shout out to
+better. Yeah. Shout out to
 
 1077
 00:56:29,467 --> 00:56:32,077
@@ -5054,7 +5054,7 @@ apparently very popular with the
 1080
 00:56:38,077 --> 00:56:44,067
 first time I heard it. Bekah
-don't ruin it. Um, which are
+don't ruin it. Which are
 
 1081
 00:56:44,067 --> 00:56:50,757
@@ -5073,7 +5073,7 @@ sharp.
 
 1084
 00:57:04,166 --> 00:57:08,306
-Bekah: Uh, uh, nice. I was not
+Bekah: Nice. I was not
 going in that direction. I was
 
 1085
@@ -5111,7 +5111,7 @@ Bekah: what's that
 1092
 00:57:31,996 --> 00:57:36,077
 Dan: 13, we don't need to talk
-about how old I was, but, uh, I
+about how old I was, but, I
 
 1093
 00:57:36,077 --> 00:57:38,536
@@ -5162,8 +5162,8 @@ this, if you're in Microsoft,
 
 1103
 00:58:08,586 --> 00:58:15,067
-sharp, um, and C plus plus is
-not, um, C plus plus is still
+sharp, and C plus plus is
+not, C plus plus is still
 
 1104
 00:58:15,067 --> 00:58:18,652
@@ -5248,12 +5248,12 @@ like, oh, yesterday I spent like
 1121
 00:59:01,961 --> 00:59:05,592
 three hours trying to get, I
-wasn't, uh, I almost went over a
+wasn't, I almost went over a
 
 1122
 00:59:05,592 --> 00:59:11,231
-PG 13 again, uh, Ruby to work
-again on my computer. And um, it
+PG 13 again, Ruby to work
+again on my computer. And it
 
 1123
 00:59:11,231 --> 00:59:14,112
@@ -5406,7 +5406,7 @@ that yesterday. It doesn't
 
 1154
 01:00:56,811 --> 01:00:59,902
-matter. Yeah. Anyway, uh,
+matter. Yeah. Anyway,
 computers are doing that. I hate
 
 1155
@@ -5420,7 +5420,7 @@ Bekah: Also. I have to go
 1157
 01:01:04,371 --> 01:01:06,652
 Dan: to leave at three, not
-three 30. Uh,
+three 30.
 
 1158
 01:01:08,422 --> 01:01:08,931
@@ -5454,7 +5454,7 @@ Bekah: birthday
 
 1165
 01:01:22,452 --> 01:01:30,702
-Dan: week. Um, Kirk, I just want
+Dan: week. Kirk, I just want
 to say a happy Kirk day to us
 
 1166
@@ -5571,7 +5571,7 @@ produced by Dan Ott and Bekah
 1190
 01:03:07,052 --> 01:03:08,441
 Hawrot Weigel. If you have
-questions or comments you can
+questions or comments, you can
 
 1191
 01:03:08,441 --> 01:03:09,830
@@ -5598,27 +5598,27 @@ our other resources on our
 
 1196
 01:03:18,351 --> 01:03:21,742
-website VirtualCoffee.io. If
+website, virtualcoffee.io. If
 you're interested in sponsoring
 
 1197
 01:03:21,742 --> 01:03:24,141
-virtual coffee you can find out
+Virtual Coffee, you can find out
 more information on our website
 
 1198
 01:03:24,411 --> 01:03:28,851
-at VirtualCoffee.io/sponsorship.
+at virtualcoffee.io/sponsorship.
 Please subscribe to our podcast
 
 1199
 01:03:28,882 --> 01:03:30,487
 and be sure to leave us a
-review. Thanks for listening and
+review. Thanks for listening,
 
 1200
 01:03:30,487 --> 01:03:32,092
-we'll
+and we'll
 
 1201
 01:03:32,092 --> 01:03:32,931

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -37,66 +37,59 @@ their stories and what they've
 learned. Today, we had a little
 
 9
-00:00:28,189 --> 00:00:31,428
+00:00:28,189 --> 00:00:32,000
 bit of a different time. Bekah
 actually came up to Cleveland
 
 10
-00:00:31,489 --> 00:00:35,959
-— where I work. And we
-actually met in person for the
+00:00:32,000 --> 00:00:36,300
+— where I work. And we actually
+met in person for the first time
 
 11
-00:00:35,959 --> 00:00:38,929
-first time ever after knowing
-each other for over three years.
+00:00:36,300 --> 00:00:39,700
+ever after knowing each other
+for over three years. And it was
 
 12
-00:00:39,259 --> 00:00:42,859
-And it was fun. And today is
-also Kirk Day which you will
+00:00:39,700 --> 00:00:44,000
+fun. And today is also Kirk Day
+which you will hear about a
 
 13
-00:00:42,859 --> 00:00:47,058
-hear about a little bit later in
-the episode. And also, Kirk
+00:00:44,000 --> 00:00:48,000
+little bit later in the episode.
+And also, Kirk joined us as
 
 14
-00:00:47,448 --> 00:00:50,959
-joined us as well, and it was
-really fun. And it was a fun
+00:00:48,000 --> 00:00:50,959
+well, and it was really fun. And
+it was a fun little thing. We
 
 15
-00:00:50,959 --> 00:00:52,008
-little thing. We streamed it
-live, we had some people sharing
-
-16
-00:00:52,008 --> 00:00:53,057
-in the
+00:00:50,959 --> 00:00:53,057
+streamed it live, we had some
+people sharing in the
 
 17
 00:00:53,088 --> 00:00:54,618
 comments, and we thought we
 would share it on the podcast
 
-18
-00:00:54,618 --> 00:00:56,148
-stream as
-
 19
-00:00:56,149 --> 00:01:00,649
-well. So enjoy, and next week
-we will get back to our regular
+00:00:54,618 --> 00:01:00,000
+stream as well. So enjoy, and
+next week we will get back to
 
 20
-00:01:00,649 --> 00:01:10,000
-schedule. Hey, we were muted the
-whole time [Bekah laughs].
+00:01:00,000 --> 00:01:10,000
+our regular schedule. Hey, we
+were muted the whole time
 
 21
 00:01:10,000 --> 00:01:12,000
-Bekah, why did you do it?
+[Bekah laughs]. Bekah, why did
+you do it?
 
 22
 00:01:13,000 --> 00:01:14,000
@@ -109,12 +102,12 @@ Dan: I was just thinking in my
 head, "Oh, I hope the sound
 
 22
-00:01:16,316 --> 00:01:17,866
-sounds good." And then, I- I
+00:01:16,316 --> 00:01:19,700
+sounds good." And then, I- I was
+like, "Huh?" I looked at the
 
 23
-00:01:17,867 --> 00:01:20,537
-was like, "Huh?" I looked at the
+00:01:19,700 --> 00:01:20,537
 mute thing and --
 
 24
@@ -263,7 +256,7 @@ read the- the right text.
 
 43
 00:02:20,501 --> 00:02:21,300
-Bekah: Post it in the chat too. 
+Bekah: Post it in the chat too.
 
 42
 00:02:21,300 --> 00:02:24,521
@@ -357,8 +350,8 @@ Bekah: A hundred and 70
 
 56
 00:03:15,700 --> 00:03:18,282
-Dan: Yeah. And it's really
-good stuff.
+Dan: Yeah. And it's really good
+stuff.
 
 56
 00:03:18,882 --> 00:03:21,117
@@ -515,14 +508,13 @@ Bekah: You -- okay.
 Dan: And I was excited.
 
 88
-00:04:50,700 --> 00:04:52,450
+00:04:50,700 --> 00:04:52,700
 Bekah: To be fair, you were
-like, "If you
+like, "If you need help with
 
 88
-00:04:52,451 --> 00:04:54,641
-need help with anything, let me
-know."
+00:04:52,700 --> 00:04:54,641
+anything, let me know."
 
 89
 00:04:54,641 --> 00:04:56,000
@@ -544,16 +536,13 @@ about that eventually. But,
 yeah. So, Kirk was there too,
 
 94
-00:05:07,700 --> 00:05:08,700
+00:05:07,700 --> 00:05:09,500
 right? And I have, like --
+I, like -- you- you know,
 
 95
-00:05:08,700 --> 00:05:10,541
-I, like -- you- you know,
+00:05:09,500 --> 00:05:11,700
 I'd heard his name or whatever.
-
-96
-00:05:10,541 --> 00:05:11,700
 I, you know, we had been --
 
 97
@@ -729,23 +718,19 @@ like -- I don't- I don't know.
 Bekah: In all the dimension?
 
 127
-00:06:30,500 --> 00:06:31,226
-Dan: You know, in- in
+00:06:30,500 --> 00:06:33,700
+Dan: You know, in- in multiple
+dimensions. I'd say, if we're
 
 126
-00:06:31,226 --> 00:06:35,000
-multiple dimensions. I'd say,
-if we're gonna use MCU, you
+00:06:33,700 --> 00:06:37,500
+gonna use MCU, you know,
+terminology though, Kirk would
 
 127
-00:06:35,000 --> 00:06:38,500
-know, terminology though, Kirk
-would be like a Nexus being,
-
-128
-00:06:38,500 --> 00:06:41,700
-right? So, there's only like,
-one Kirk-
+00:06:37,500 --> 00:06:41,700
+be like a Nexus being, right?
+So, there's only like, one Kirk-
 
 129
 00:06:42,000 --> 00:06:42,300
@@ -787,8 +772,7 @@ Bekah: Yeah.
 
 132
 00:06:49,300 --> 00:06:50,000
-Dan: That's what I mean.
-Yeah.
+Dan: That's what I mean. Yeah.
 
 133
 00:06:50,000 --> 00:06:50,300
@@ -925,8 +909,8 @@ and Bryan were like,
 
 159
 00:08:15,000 --> 00:08:16,500
-"[Talks fast] Talk, talk,
-talk, talk, talk."
+"[Talks fast] Talk, talk, talk,
+talk, talk."
 
 160
 00:08:16,500 --> 00:08:20,187
@@ -953,23 +937,19 @@ back to having productive
 conversations and making
 
 163
-00:08:35,300 --> 00:08:37,797
+00:08:35,300 --> 00:08:39,000
 progress on all the things that
-we were
+we were really excited about
 
 165
-00:08:37,797 --> 00:08:39,566
-really excited about doing, and
-making sure that they happen.
+00:08:39,000 --> 00:08:42,500
+doing, and making sure that they
+happen. And -- like, for me, I
 
 167
-00:08:41,726 --> 00:08:45,500
-And -- like, for me, I like --
-had not really either am heard
-
-168
-00:08:45,500 --> 00:08:46,486
-about documentation,
+00:08:42,500 --> 00:08:46,486
+like -- had not really either am
+heard about documentation,
 
 169
 00:08:46,486 --> 00:08:49,697
@@ -1003,8 +983,8 @@ people through the documentation
 
 175
 00:09:04,636 --> 00:09:08,836
-became something that was
-like a change in my life, you
+became something that was like a
+change in my life, you
 
 176
 00:09:08,836 --> 00:09:11,700
@@ -1275,8 +1255,8 @@ Bekah: No, wait. Yeah,
 
 222
 00:11:24,131 --> 00:11:27,731
-So, okay. So maybe let's
-go back a little bit so I can
+So, okay. So maybe let's go back
+a little bit so I can
 
 223
 00:11:27,731 --> 00:11:31,182
@@ -1321,8 +1301,8 @@ kidding [all laugh].
 
 228
 00:11:53,682 --> 00:11:56,321
-Bekah: So, I did not -- I
-didn't take any coding tests or
+Bekah: So, I did not -- I didn't
+take any coding tests or
 
 229
 00:11:56,321 --> 00:11:58,960
@@ -1843,7 +1823,7 @@ that everything that I did was
 good.
 
 306
-00:16:22,700 --> 00:16:25,000 
+00:16:22,700 --> 00:16:25,000
 Bekah: She 100% did not say
 that.
 
@@ -2248,18 +2228,14 @@ tell? We did, like- we did, like
 [laughs], this is -- yeah,
 
 372
-00:19:43,092 --> 00:19:46,872
+00:19:43,092 --> 00:19:48,000
 very polished, you know, thing.
-No. But what I mean is
+No. But what I mean is like, I
 
 374
-00:19:46,872 --> 00:19:51,500
-like, I know what socially
-is expected of me in this
-
-375
-00:19:51,500 --> 00:19:52,210
-situation.
+00:19:48,000 --> 00:19:52,210
+know what socially is expected
+of me in this situation.
 
 376
 00:19:52,241 --> 00:19:56,471
@@ -2979,8 +2955,8 @@ where are we breaking out to?
 
 487
 00:25:33,000 --> 00:25:35,000
-Dan: I was trying to turn off the
-[inaudible].
+Dan: I was trying to turn off
+the [inaudible].
 
 487
 00:25:34,300 --> 00:25:37,700
@@ -3759,10 +3735,10 @@ could sit-
 609
 00:32:01,000 --> 00:32:02,000
 Bekah: Oh, I didn't have an
-iPod. 
+iPod.
 
 609
-00:32:02,000 --> 00:32:04,707 
+00:32:02,000 --> 00:32:04,707
 Dan: -in those cars. You could
 sit next to your friend in the
 
@@ -5657,7 +5633,7 @@ pancakes myself. Cuz I know --
 
 869
 00:45:53,052 --> 00:45:54,000
-Bekah: You can freeze them- 
+Bekah: You can freeze them-
 
 870
 00:45:54,000 --> 00:45:55,000
@@ -6388,7 +6364,7 @@ jump [Bekah chuckles] on a
 unicycle, waving to Nick, and
 
 970
-00:51:11,000 --> 00:51:14,500 
+00:51:11,000 --> 00:51:14,500
 then, like, seeing them veer off
 into a tree and yelling "Sacré
 
@@ -6783,9 +6759,13 @@ Bekah: I love Dreamweaver.
 Kirk: Dreamweaver!
 
 1027
-00:54:23,967 --> 00:54:26,456
+00:54:23,967 --> 00:54:26,000
 Bekah: That was the first time I
-ever code, it was in Dreamweaver.
+ever code, it was in
+
+1028
+00:54:26,000 --> 00:54:26,456
+Dreamweaver.
 
 1028
 00:54:26,487 --> 00:54:26,666

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -54,7 +54,7 @@ each other for over three years.
 12
 00:00:39,259 --> 00:00:42,859
 And it was fun. And today is
-also a Kirk Day which you will
+also Kirk Day which you will
 
 13
 00:00:42,859 --> 00:00:47,058
@@ -199,12 +199,12 @@ Kirk Day.
 
 36
 00:01:50,057 --> 00:01:50,656
-Dan: Yeah.
+Dan: Yes.
 
 35
 00:01:50,656 --> 00:01:53,027
 Bekah: Because it is preserved
-everywhere, because perk is
+everywhere, because Kirk is
 
 36
 00:01:53,027 --> 00:01:56,266
@@ -219,19 +219,20 @@ can.
 00:01:57,300 --> 00:01:58,000
 Dan: Agreed.
 
+39
 00:01:58,500 --> 00:02:01,186
 Bekah: Dan, would you like to
-introduce what international
+introduce what international,
 
 38
 00:02:01,277 --> 00:02:03,917
-dimensional disciplinary Kirk
-day is?
+dimensional, disciplinary Kirk
+day is [chuckles]?
 
 39
 00:02:05,027 --> 00:02:08,000
 Dan: So, was it just a year
-ago-
+ago?
 
 40
 00:02:08,000 --> 00:02:09,500
@@ -239,12 +240,16 @@ Bekah: It was a year ago, today.
 
 41
 00:02:08,500 --> 00:02:10,727
-Dan: two years ago? Today? Yes,
+Dan: Two years ago? Today? Yes,
 
 40
-00:02:10,757 --> 00:02:16,500
-Kirk had a tweet where he showed
--- how should I read the --
+00:02:10,757 --> 00:02:16,300
+Kirk had a tweet where he --
+should I -- how should I read
+
+41
+00:02:16,300 --> 00:02:16,500
+the --
 
 41
 00:02:16,500 --> 00:02:17,800
@@ -256,6 +261,7 @@ the announcement.
 Dan: I feel like I should have
 read the- the right text.
 
+43
 00:02:20,501 --> 00:02:21,300
 Bekah: Post it in the chat too. 
 
@@ -283,14 +289,14 @@ made a function called Missy
 Elliott that takes data
 
 45
-00:02:32,981 --> 00:02:37,572
-structure, flips it and reverses
-it. I have ascended." And then,
+00:02:32,981 --> 00:02:36,000
+structure, flips it, and
+reverses it. I have ascended."
 
 46
-00:02:37,662 --> 00:02:42,000
-very shortly after that,
-Missy Elliott responded
+00:02:36,000 --> 00:02:42,000
+And then, very shortly after
+that, Missy Elliott responded
 
 47
 00:02:42,000 --> 00:02:45,700
@@ -328,7 +334,7 @@ It was- it was really, really
 52
 00:02:59,981 --> 00:03:03,700
 awesome [laughs]. And everybody
-saw it, and perks, you know,
+saw it, and Kirk's, you know,
 
 53
 00:03:03,700 --> 00:03:03,822
@@ -403,7 +409,7 @@ the Kirk.
 63
 00:03:43,000 --> 00:03:45,822
 Bekah: So maybe we should tell
-our Kirk's origin story.
+our Kirk origin story.
 
 65
 00:03:47,771 --> 00:03:51,000
@@ -412,8 +418,7 @@ idea [laughs]. Do you want me to
 
 66
 00:03:51,000 --> 00:03:52,000
-go first? Do you want to go
-first?
+go first? Do you wanna go first?
 
 67
 00:03:52,700 --> 00:03:53,300
@@ -481,13 +486,9 @@ Was really, like, leading up
 to Hacktoberfest that year. So
 it was two years ago. And ...
 
-80
-00:04:32,431 --> 00:04:35,076
-Bekah
-
 81
-00:04:35,096 --> 00:04:38,997
-and I, you know, we worked
+00:04:32,431 --> 00:04:38,997
+Bekah and I, you know, we worked
 together and I had known Sarah
 
 82
@@ -502,7 +503,7 @@ stuff. And I could just
 
 85
 00:04:47,201 --> 00:04:49,700
-kinda wrote me in for
+kinda wrote me in, right? For
 Hacktoberfest to, like, help.
 
 86
@@ -515,7 +516,7 @@ Dan: And I was excited.
 
 88
 00:04:50,700 --> 00:04:52,450
-Bekah:  To be fair, you were
+Bekah: To be fair, you were
 like, "If you
 
 88
@@ -569,22 +570,19 @@ Dan: He was still TK.
 Bekah: He was still TK.
 
 100
-00:05:15,000 --> 00:05:16,091
-Dan: That's right. He was
+00:05:15,000 --> 00:05:18,300
+Dan: That's right. He was just
+the mysterious TK, which made
 
 97
-00:05:16,091 --> 00:05:21,132
-just the mysterious TK, which
-made me, you know, want to know
+00:05:18,300 --> 00:05:23,500
+me, you know, want to know him
+more, you know? Because, anyway,
 
 98
-00:05:21,132 --> 00:05:24,132
-him more, you know? Because,
-anyway, that has a mysterious
-
-99
-00:05:24,132 --> 00:05:25,000
-name, you know? You need to-
+00:05:23,500 --> 00:05:24,300
+that has a mysterious name, you
+know? You need to-
 
 100
 00:05:24,300 --> 00:05:25,500
@@ -606,12 +604,12 @@ Dan: And, yeah. And then that
 
 101
 00:05:29,831 --> 00:05:32,569
-September leading up to
-that October, it was a lot of
+September leading up to that
+October. It was a lot of
 
 102
 00:05:32,569 --> 00:05:35,307
-Kirk and I were
+-- Kirk and I were
 
 103
 00:05:35,307 --> 00:05:37,976
@@ -619,22 +617,18 @@ Kirk and I were
 the site and that's when the
 
 104
-00:05:37,976 --> 00:05:39,206
+00:05:37,976 --> 00:05:40,000
 first like this -- the current
 version of the site happened,
 
-105
-00:05:39,206 --> 00:05:40,436
-you
-
 106
-00:05:40,437 --> 00:05:41,772
-know? We made the leap with like
--- that which has brought us the
+00:05:40,000 --> 00:05:42,000
+you know? We made the leap with
+like -- that which has brought
 
 107
-00:05:41,772 --> 00:05:43,107
-site
+00:05:42,000 --> 00:05:43,107
+us the site
 
 108
 00:05:43,107 --> 00:05:45,357
@@ -682,7 +676,7 @@ are going
 117
 00:06:04,497 --> 00:06:07,976
 to interact with Virtual Coffee,
-and like how we need
+and like how we need may-
 
 118
 00:06:08,307 --> 00:06:11,156
@@ -700,7 +694,7 @@ was like fun to
 
 121
 00:06:14,637 --> 00:06:16,947
-hang out with them. And again,
+hang out with him. And again,
 a lot of, like, respect for
 
 122
@@ -732,7 +726,7 @@ like -- I don't- I don't know.
 
 126
 00:06:29,500 --> 00:06:30,500
-Bekah: In all dimension?
+Bekah: In all the dimension?
 
 127
 00:06:30,500 --> 00:06:31,226
@@ -755,7 +749,7 @@ one Kirk-
 
 129
 00:06:42,000 --> 00:06:42,300
-Bekah: Yes.
+Bekah: Yes. Mm-hmm.
 
 130
 00:06:42,500 --> 00:06:43,500
@@ -813,12 +807,12 @@ Bekah: He's the right Kirk.
 Dan: Exactly [laughs].
 
 135
-00:06:56,427 --> 00:06:58,992
+00:06:56,427 --> 00:07:01,400
 Bekah: I will tell my Kirk
 origin story. I don't remember
 
 136
-00:06:58,992 --> 00:07:01,557
+00:07:01,400 --> 00:07:01,557
 it
 
 137
@@ -868,13 +862,13 @@ And then, I was like, "I think
 this person knows me?" And I had
 
 145
-00:07:30,000 --> 00:07:30,716
-to try and figure
+00:07:30,000 --> 00:07:31,500
+to try and figure it out [laughs].
 
 146
-00:07:30,716 --> 00:07:33,206
-it out [laughs]. And he would
-sit in this office, like, with a
+00:07:31,500 --> 00:07:33,206
+And he would sit in this office,
+like, with this
 
 147
 00:07:33,206 --> 00:07:38,966
@@ -903,7 +897,7 @@ maybe we're moving into
 
 152
 00:07:53,500 --> 00:07:54,566
-friendship right now.
+friendship right now."
 
 153
 00:07:54,987 --> 00:07:57,131
@@ -922,17 +916,17 @@ Somehow, Kirk ended up on the
 157
 00:08:04,700 --> 00:08:10,766
 Hacktoberfest team. And it was
-me, Dan, Sarah, Brian, and Kirk.
+me, Dan, Sarah, Bryan, and Kirk.
 
 158
 00:08:11,276 --> 00:08:15,000
 And I feel like me, Sarah, Dan,
-and Brian were like,
+and Bryan were like,
 
 159
 00:08:15,000 --> 00:08:16,500
-"[in fast speed] Talk, talk,
-talk."
+"[Talks fast] Talk, talk,
+talk, talk, talk."
 
 160
 00:08:16,500 --> 00:08:20,187
@@ -945,25 +939,22 @@ think about this for a second?"
 shall -- probably should."
 
 162
-00:08:26,000 --. 00:08:27,000
+00:08:26,000 --> 00:08:27,000
 Dan: Notorious [??].
 
 163
-00:08:27,500 --> 00:08:29,156
-Bekah: So, Kirk was always
+00:08:27,500 --> 00:08:32,500
+Bekah: So, Kirk was always doing
+a great job of roping us all
 
 162
-00:08:29,156 --> 00:08:34,466
-doing a great job of roping
-us all back to having productive
+00:08:32,500 --> 00:08:35,300
+back to having productive
+conversations and making
 
 163
-00:08:34,466 --> 00:08:36,131
-conversations and making
+00:08:35,300 --> 00:08:37,797
 progress on all the things that
-
-164
-00:08:36,131 --> 00:08:37,796
 we were
 
 165
@@ -974,7 +965,7 @@ making sure that they happen.
 167
 00:08:41,726 --> 00:08:45,500
 And -- like, for me, I like --
-had not really ever I've heard
+had not really either am heard
 
 168
 00:08:45,500 --> 00:08:46,486
@@ -1017,7 +1008,7 @@ like a change in my life, you
 
 176
 00:09:08,836 --> 00:09:11,700
-know, I will make no big deal,
+know? I will make no big deal,
 but [laughs] --
 
 177
@@ -1026,8 +1017,8 @@ Dan: No biggie.
 
 178
 00:09:13,000 --> 00:09:16,246
-Bekah: That's all. So, all
-right. I'm
+Bekah: [Laughs] That's all. So,
+all right. I'm
 
 178
 00:09:16,246 --> 00:09:19,067
@@ -1041,8 +1032,8 @@ be my best friend ever since.
 
 180
 00:09:22,336 --> 00:09:27,047
-Dan: Yeah. So we just
-got a comment from David saying,
+Dan: Yeah. So we just got a
+comment from David saying,
 
 181
 00:09:27,057 --> 00:09:28,876
@@ -1172,12 +1163,12 @@ Fine.
 201
 00:10:18,491 --> 00:10:21,700
 I'll be fair. It was pandemic.
-And there was no [laughs] work.
+And there was no work.
 
 202
 00:10:21,700 --> 00:10:26,500
-So, he fired me on accident,
-apparently.
+So, [laughs] he fired me on
+accident, apparently.
 
 203
 00:10:26,500 --> 00:10:27,462
@@ -1204,8 +1195,8 @@ ago [laughs].
 
 208
 00:10:39,731 --> 00:10:45,432
-Dan: So, anyway, yes.
-So, I don't know about you,
+Dan: So, anyway, yes. So, I
+don't know about you,
 
 209
 00:10:45,432 --> 00:10:50,500
@@ -1242,8 +1233,8 @@ assignment.
 
 215
 00:11:02,500 --> 00:11:04,721
-Dan: Yeah. Well, we
-didn't talk about it ahead of
+Dan: Yeah. Well, we didn't talk
+about it ahead of
 
 216
 00:11:04,721 --> 00:11:07,300
@@ -1251,17 +1242,13 @@ times. I almost, like, texted
 you. I almost, like, I almost
 
 217
-00:11:07,300 --> 00:11:08,772
-asked you, and I
-
-217
-00:11:08,772 --> 00:11:10,751
-should have. Because then we
-could have just been totally,
+00:11:07,300 --> 00:11:10,000
+asked you, and I should have.
+Because then we could have just
 
 219
-00:11:10,751 --> 00:11:11,000
-you know?
+00:11:10,000 --> 00:11:11,000
+been totally, you know?
 
 218
 00:11:11,000 --> 00:11:13,152
@@ -1329,7 +1316,7 @@ Dan: Not really, but ...
 seriously [laughs]. No, just
 
 228
-00:11:50,300 --. 00:11:50,500
+00:11:50,300 --> 00:11:50,500
 kidding [all laugh].
 
 228
@@ -1343,7 +1330,7 @@ have to
 
 230
 00:11:58,961 --> 00:12:03,201
-do any strange problems that
+do any s-strange problems that
 make no difference in the world.
 
 231
@@ -1400,22 +1387,18 @@ you [all laugh]. Well, yeah. It
 
 236
 00:12:26,211 --> 00:12:27,700
-was rou- it was a rough summer.
+was ru- it was a rough summer.
 It was a weird summer.
 
 237
-00:12:28,000 --> 00:12:29,392
+00:12:28,000 --> 00:12:30,000
 Bekah: That was really rough.
-And that's how
+And that's how Virtual Coffee
 
 238
-00:12:29,392 --> 00:12:31,191
-Virtual Coffee started too.
-Because I was getting assigned
-
-239
-00:12:31,191 --> 00:12:32,990
-with
+00:12:30,000 --> 00:12:32,991
+started too. Because I was
+getting assigned with
 
 240
 00:12:32,991 --> 00:12:37,491
@@ -1482,7 +1465,7 @@ me.
 
 252
 00:13:14,700 --> 00:13:15,000
-Bekah: Yes.
+Bekah: Yeah.
 
 252
 00:13:15,000 --> 00:13:15,626
@@ -1518,7 +1501,7 @@ you -- yeah. No,
 
 256
 00:13:21,807 --> 00:13:25,677
-it's weird. Good weird. But
+it's weird. Good weird, but
 it's- it's weird, you know?
 
 257
@@ -1535,17 +1518,13 @@ Bekah: Yeah. Okay. Let's see.
 Let me look at this chat.
 
 258
-00:13:34,000 --> 00:13:34,615
-[Chuckles] Yes,
+00:13:34,000 --> 00:13:36,700
+[Laughs] Yes, Nick. Exactly.
+"Dan responded, 'I'm looking for
 
 259
-00:13:34,647 --> 00:13:37,500
-Nick. Exactly. Dan responded,
-"I'm looking for someone to fire
-
-260
-00:13:37,500 --> 00:13:37,797
-eventually."
+00:13:36,700 --> 00:13:37,500
+someone to fire eventually.'"
 
 261
 00:13:37,797 --> 00:13:38,700
@@ -1581,41 +1560,33 @@ and then [inaudible].
 Bekah: No, I had no coding
 tests. We had a conversation. I
 
-263
-00:13:47,051 --> 00:13:48,476
-don't
-
 264
-00:13:48,476 --> 00:13:50,486
-know if Dan remembers it, but I
-remember --
+00:13:47,051 --> 00:13:50,486
+don't know if Dan remembers it,
+but I remember --
 
 265
-00:13:50,486 --> 00:13:54,500
+00:13:50,486 --> 00:13:55,500
 Dan: I did. Yeah. I mean, I
 didn't know what I was doing
 
 266
-00:13:54,500 --> 00:13:55,706
-either. It was -- I mean,
+00:13:55,500 --> 00:13:58,000
+either. It was -- I mean, this
+is the first time I ever -- and
 
 266
-00:13:55,706 --> 00:13:57,776
-this is the first time I ever --
-and to be clear, like, you
-
-267
-00:13:57,776 --> 00:13:59,846
-weren't
+00:13:58,000 --> 00:13:59,84
+to be clear, like, you weren't
 
 268
 00:13:59,846 --> 00:14:03,506
-an employee, so, you know? My
-whole thing was contractor, you
+an employee, so, you know? I --
+my whole thing was contractor,
 
 269
 00:14:03,506 --> 00:14:06,386
-know? Cuz I'm a contractor
+you know? Cuz I'm a contractor
 too. But, yeah. I'd never done
 
 271
@@ -1624,22 +1595,18 @@ that before. And like, I really
 jumped into, like, very ADHD
 
 272
-00:14:08,576 --> 00:14:10,766
-style,
+00:14:08,576 --> 00:14:15,500
+style, like, no real plan, no
+real, you know, guidelines for
 
 273
-00:14:10,767 --> 00:14:16,407
-like, no real plan, no real, you
-know, guidelines for myself or
+00:14:15,500 --> 00:14:18,500
+myself or for anybody else or
+anything like that. And it
 
 274
-00:14:16,407 --> 00:14:18,266
-for anybody else or anything
-like that. And it worked out
-
-275
-00:14:18,266 --> 00:14:20,125
-very well.
+00:14:18,500 --> 00:14:20,125
+worked out very well.
 
 276
 00:14:20,125 --> 00:14:22,000
@@ -1653,7 +1620,7 @@ was- it was- it was fun.
 
 277
 00:14:28,317 --> 00:14:31,772
-I'm -- I've been missing, you
+I'm -- I've been missing -- you
 know, Bekah, you gotta ... I
 
 278
@@ -1804,25 +1771,21 @@ Bekah: Can confirm.
 294
 00:15:35,000 --> 00:15:36,642
 Dan: Yeah. I mean, the two beers
-probably-
+probably- probably not bad
 
 295
-00:15:37,991 --> 00:15:39,491
--probably not bad either. But,
-I blame -- yeah.
-
-296
-00:15:39,491 --> 00:15:40,991
-I blame- I blame
+00:15:37,991 --> 00:15:42,500
+either. But, I blame -- yeah. I
+blame- I blame that on that- on
 
 297
-00:15:41,471 --> 00:15:45,162
-that on that- on that mental
-lapse. But I want to stand firm
+00:15:42,500 --> 00:15:46,000
+that mental lapse. But I want to
+stand firm that I did not fire
 
 298
-00:15:45,162 --> 00:15:46,451
-that I did not fire anybody.
+00:15:46,000 --> 00:15:46,451
+anybody.
 
 299
 00:15:47,201 --> 00:15:49,991
@@ -1937,26 +1900,23 @@ that means [laughs].
 Dan: Ooh, Nick.
 
 311
-00:16:47,000 --> 00:16:47,781
-Bekah: Sometimes, I,
+00:16:47,000 --> 00:16:49,300
+Bekah: Sometimes, I, like, very
+frequently will spit out water
 
 312
-00:16:47,782 --> 00:16:50,241
-like, very frequently will spit
-out water when I drink it. So I
+00:16:49,300 --> 00:16:53,000
+when I drink it. So I need to
+try very hard to not drink and
 
 313
-00:16:50,241 --> 00:16:53,751
-need to try very hard to not
-drink and laugh at the same
-
-314
-00:16:53,751 --> 00:16:54,000
-time.
+00:16:53,000 --> 00:16:54,000
+laugh at the same time.
 
 314
 00:16:54,000 --> 00:16:59,966
-Dan:  Hmm, wait. Who's ... yeah.Somebody's episode, that was a
+Dan: Hmm, wait. Who's ... yeah.
+Somebody's episode. That was a
 
 315
 00:16:59,966 --> 00:17:00,500
@@ -1982,15 +1942,14 @@ do it. I watched you swallow or,
 317
 00:17:04,767 --> 00:17:07,287
 like, you know, start to drink
-water. And then Helen
+water. And then Helen said
 
 319
 00:17:07,287 --> 00:17:09,500
-said something hilarious, and,
-yeah.
+something hilarious, and, yeah.
 
 320
-00:17:09,500 --> 00:17:10,500 
+00:17:09,500 --> 00:17:10,500
 Bekah: I didn't mute myself.
 
 321
@@ -2031,7 +1990,7 @@ can, like-
 Bekah: Yeah.
 
 326
-00:17:26,600 --> 00:17:28,
+00:17:26,600 --> 00:17:28,500
 Dan: -in Zoom, sometimes, you
 know? Where, like, you know,
 
@@ -2064,40 +2023,28 @@ there's been some- there's been
 some- there's been some moments.
 
 332
-00:17:42,477 --> 00:17:43,842
+00:17:42,477 --> 00:17:44,700
 Bekah: Yeah. Yeah. There are
 many moments on the podcast.
 
-333
-00:17:43,842 --> 00:17:45,207
-We've
-
 334
-00:17:45,207 --> 00:17:46,646
-progressed so much. When we
-first started the podcast, I
-
-335
-00:17:46,646 --> 00:17:48,085
-would
+00:17:44,700 --> 00:17:47,700
+We've progressed so much. When
+we first started the podcast, I
 
 336
-00:17:48,086 --> 00:17:49,541
-laugh uncontrollably for the
-first five minutes and I could
-
-337
-00:17:49,541 --> 00:17:50,996
-never
+00:17:47,700 --> 00:17:50,541
+would laugh uncontrollably for
+the first five minutes and I
 
 338
-00:17:50,997 --> 00:17:54,000
-do the introduction. I -- maybe
-there's -- I don't know if
+00:17:50,541 --> 00:17:53,700
+could never do the introduction.
+I -- maybe there's -- I don't
 
 339
-00:17:54,000 --> 00:17:55,000
-there's any [inaudible]
+00:17:53,700 --> 00:17:55,000
+know if there's any [inaudible]
 [laughs].
 
 340
@@ -2106,27 +2053,26 @@ Dan: No, we have it all on tape,
 for sure. We sure have it all
 
 341
-00:17:56,700 --> 00:17:58,346
+00:17:56,700 --> 00:17:59,300
 recorded. I don't know if --
+yeah. I don't know how much
 
 341
-00:17:58,346 --> 00:18:00,566
-yeah. I don't know how much
+00:17:59,300 --> 00:18:04,000
 video we have of it, but, like,
+we have a lot of views of- of
 
 343
-00:18:02,787 --> 00:18:04,500
-we have a lot of views of- of
+00:18:04,000 --> 00:18:05,500
 the, like, trying to do the
-
-344
-00:18:04,500 --> 00:18:05,500
 intros and stuff.
 
+344
 00:18:05,500 --> 00:18:06,700
-Bekah: I just couldn't [laughs].
+Bekah: [Laughs] I just couldn't.
 I just would -- just --
 
+345
 00:18:06,700 --> 00:18:09,000
 Dan: It's so funny. Cuz you're
 so good at it. Like,
@@ -2147,7 +2093,7 @@ script part-
 
 348
 00:18:15,057 --> 00:18:15,500
-Bekah:  It was like-
+Bekah: It was like-
 
 349
 00:18:15,300 --> 00:18:16,000
@@ -2159,7 +2105,8 @@ Bekah: -I was so nervous.
 
 351
 00:18:16,700 --> 00:18:18,000
-Dan: Yeah. That was [inaudible].
+Dan: Yeah. I feel like that was
+[inaudible].
 
 352
 00:18:17,000 --> 00:18:18,700
@@ -2197,7 +2144,7 @@ Dan: Yeah.
 
 355
 00:18:37,000 --> 00:18:38,231
-Bekah: Promoted to customer
+Bekah: Promote it to customer
 [all laugh].
 
 354
@@ -2260,7 +2207,7 @@ me, it's sort of knowing exactly
 365
 00:19:24,692 --> 00:19:26,700
 what, like, I was supposed to
-do with-
+do-
 
 366
 00:19:26,700 --> 00:19:27,000
@@ -2298,11 +2245,11 @@ tell? We did, like- we did, like
 
 371
 00:19:40,916 --> 00:19:43,061
-[laughs], this is -- yeah.
+[laughs], this is -- yeah,
 
 372
 00:19:43,092 --> 00:19:46,872
-Very polished, you know, thing.
+very polished, you know, thing.
 No. But what I mean is
 
 374
@@ -2402,23 +2349,15 @@ Dan: Cuz that's like,
 "Hey, this is what you're
 supposed to do now," you know?
 
-391
-00:20:29,000 --> 00:20:29,442
-But like,
-
 392
-00:20:29,471 --> 00:20:33,000
-walking up to somebody and
-trying to, like ... that's-
-
-393
-00:20:33,000 --> 00:20:33,841
-that's what I --
+00:20:29,000 --> 00:20:33,000
+But like, walking up to somebody
+and trying to, like ... that's-
 
 394
-00:20:34,001 --> 00:20:35,300
-like, I really struggled with
-that. That-
+00:20:33,000 --> 00:20:35,300
+that's what I -- like, I really
+struggled with that. That-
 
 395
 00:20:35,300 --> 00:20:35,500
@@ -2426,22 +2365,18 @@ Bekah: Yeah.
 
 396
 00:20:35,500 --> 00:20:36,700
-Dan: -that's the kind of
-stuff that I struggled with,
+Dan: -that's the kind of stuff
+that I struggled with,
 
 395
-00:20:36,700 --> 00:20:38,922
+00:20:36,700 --> 00:20:42,500
 you know? Is those- those, like,
-situations ...
+situations ... where it's an
 
 396
-00:20:39,672 --> 00:20:45,011
-where it's an unfamiliar
-territory or like, you know, I
-
-397
-00:20:45,011 --> 00:20:45,112
-dunno.
+00:20:42,500 --> 00:20:45,112
+unfamiliar territory or like ...
+you know? I dunno.
 
 398
 00:20:45,612 --> 00:20:46,000
@@ -2449,7 +2384,7 @@ Bekah: Yeah.
 
 399
 00:20:46,000 --> 00:20:47,000
-Dan: Something like that. So -- 
+Dan: Something like that. So --
 
 400
 00:20:47,000 --> 00:20:48,311
@@ -2462,8 +2397,8 @@ Dan: Super [inaudible].
 
 399
 00:20:48,551 --> 00:20:51,500
-Bekah: -oldest — my 12 year old
-— he was talking about how great
+Bekah: -oldest — my 12-year-old.
+He was talking about how great
 
 400
 00:20:51,500 --> 00:20:54,500
@@ -2551,7 +2486,7 @@ doesn't naturally -- like, he
 
 412
 00:21:25,571 --> 00:21:29,382
-doesn't almost like impulsively,
+does it almost like impulsively,
 you know? But like- like, in
 
 413
@@ -2576,12 +2511,12 @@ Bekah: Right.
 417
 00:21:35,800 --> 00:21:36,942
 Dan: And he's not, like, hitting
-on anybody or
+on anybody or anything like
 
 417
 00:21:36,942 --> 00:21:39,281
-anything like that. But he would
-just like ... talking to them.
+that. But he would just like ...
+talking to them.
 
 418
 00:21:39,281 --> 00:21:40,000
@@ -2599,31 +2534,23 @@ Bekah: They would talk to each
 other in the elevator.
 
 419
-00:21:42,791 --> 00:21:42,800
-Dan: It was fun for the break.
-He's, like, great
+00:21:42,791 --> 00:21:43,700
+Dan: [Inaudible]. He's, like,
+great guy. You know what I mean?
 
 420
-00:21:42,800 --> 00:21:45,011
-guy. You know what I mean? And
-like, but that's just
+00:21:43,700 --> 00:21:48,000
+And like, but that's just how he
+is, you know? And ... yeah.
 
 420
-00:21:45,071 --> 00:21:50,000
-how he is, you know?  And ...
-yeah. Somebody said something
-
-421
-00:21:50,000 --> 00:21:51,131
-about --
+00:21:49,300 --> 00:21:53,000
+Somebody said something about --
+Joe said some- "What do I do
 
 422
-00:21:52,031 --> 00:21:53,111
-Joe said some- "What do I do
+00:21:53,000 --> 00:21:55,300
 with my hands?" That's a big
-
-423
-00:21:53,111 --> 00:21:55,300
 thing with me too. And honestly,
 
 424
@@ -2767,31 +2694,23 @@ so much. It's distracting."
 Like, whatever. Like, I'm gonna
 
 445
-00:22:53,000 --> 00:22:53,487
-move my
-
-445
-00:22:53,487 --> 00:22:56,300
-hands as much as I want it.
-Like, because I can. I said, I
+00:22:53,000 --> 00:22:56,300
+move my hands as much as I want
+it. Like, because I can. I said,
 
 446
-00:22:56,300 --> 00:22:56,967
--- we've
-
-446
-00:22:56,967 --> 00:23:00,356
-got spinny -- Dan's got spinny
-chair. So I got to do a lot of
+00:22:56,300 --> 00:22:59,700
+I -- we've got spinny -- Dan's
+got spinny chair. So I got to do
 
 447
-00:23:00,356 --> 00:23:04,700
-spinning [chuckles]. This is-
-this is what I do. I move all
+00:22:59,700 --> 00:23:04,300
+a lot of spinning [chuckles].
+This is- this is what I do. I
 
 449
-00:23:04,700 --> 00:23:05,700
-the time. But, like-
+00:23:04,300 --> 00:23:05,700
+move all the time. But, like-
 
 450
 00:23:05,700 --> 00:23:06,700
@@ -2803,12 +2722,12 @@ Bekah: -when I'm in front of the
 camera in my office,
 
 450
-00:23:07,907 --> 00:23:09,817
+00:23:07,907 --> 00:23:12,300
 like, I very much try -- I- I
+have to try very hard to sit
 
 451
-00:23:09,836 --> 00:23:13,000
-have to try very hard to sit
+00:23:12,300 --> 00:23:13,000
 still [chuckles]-
 
 452
@@ -2816,12 +2735,12 @@ still [chuckles]-
 Dan: Yeah.
 
 453
-00:23:13,500 --> 00:23:14,997
+00:23:13,500 --> 00:23:16,500
 Bekah: -and not move my hands
+everywhere because that is not
 
 452
-00:23:14,997 --> 00:23:17,757
-everywhere because that is not
+00:23:16,500 --> 00:23:17,757
 my natural state of being.
 
 453
@@ -2840,22 +2759,18 @@ Bekah: We did the wave one time
 at Virtual Coffee-
 
 455
-00:23:28,500 00:23:29,000
+00:23:28,500 --> 00:23:29,000
 Dan: Ooh, right.
 
 456
-00:23:28,550 --> 00:23:29,467
-Bekah: -in my breakout
+00:23:28,550 --> 00:23:31,700
+Bekah: -in my breakout room. We,
+like, alf- we- we alphabetized
 
 455
-00:23:29,467 --> 00:23:33,457
-room. We, like, alf- we- we
-alphabetized everybody, and then
-
-456
-00:23:33,576 --> 00:23:35,946
-everybody went. It was very
-exciting.
+00:23:31,700 --> 00:23:36,000
+everybody, and then everybody
+went. It was very exciting.
 
 457
 00:23:39,997 --> 00:23:43,000
@@ -2868,8 +2783,8 @@ Bekah: Oh, Marie.
 
 459
 00:23:44,300 --> 00:23:49,000
-Dan: We will see you, Marie. Um,
-yeah. I dunno.
+Dan: We will see you, Marie.
+Yeah. I dunno.
 
 458
 00:23:49,017 --> 00:23:53,000
@@ -2882,7 +2797,8 @@ on?
 
 460
 00:23:54,326 --> 00:24:00,000
-Dan: I dunno. It is Kirk Day.
+Dan: I don't know. It is Kirk
+Day.
 
 461
 00:24:01,000 --> 00:24:02,606
@@ -2932,13 +2848,13 @@ Bekah: Yeah.
 
 469
 00:24:26,000 --> 00:24:27,700
-Dan: Oh, man. It's crazy. It's
-crazy.
+Dan: Oh, man. It's- it's crazy.
+It's crazy.
 
 467
 00:24:28,000 --> 00:24:31,342
 Bekah: Kirk is at work. What's
-work? Do people do that?
+work? Can people do that?
 
 469
 00:24:32,662 --> 00:24:37,192
@@ -2963,21 +2879,17 @@ asked. That's a good question.
 Dan: Ooh.
 
 474
-00:24:42,000 --> 00:24:44,071
+00:24:42,000 --> 00:24:46,000
 Bekah: So, in our Slack right
-now, most of
+now, most of us have put our
 
 474
-00:24:44,071 --> 00:24:49,422
-us have put our profile down,
-flipped it, and reversed it. But
-
-475
-00:24:49,422 --> 00:24:50,082
-with Kirk's --
+00:24:46,000 --> 00:24:50,082
+profile down, flipped it, and
+reversed it. But with Kirk's --
 
 476
-00:24:50,561 --> 00:24:52,000
+00:24:50,082 --> 00:24:52,000
 Dan: Huh. I see him. Kiirk.
 
 477
@@ -2996,7 +2908,7 @@ gonna try to get Kirk in to
 
 480
 00:24:59,500 --> 00:24:59,700
-join.
+join --
 
 481
 00:24:59,700 --> 00:25:01,700
@@ -3006,11 +2918,11 @@ we disappoint you-
 477
 00:25:01,300 --> 00:25:03,500
 Dan: I just have- I just have to
-remember how, you know,
+remember how, you know, work
 
 478
 00:25:03,500 --> 00:25:04,000
-[inaudible].
+this [inaudible].
 
 479
 00:25:04,000 --> 00:25:06,402
@@ -3029,12 +2941,12 @@ Dan: Him is celebrity.
 479
 00:25:09,007 --> 00:25:11,612
 Bekah: At least take -- 10 fakes
-in- in
+in- in the
 
 480
 00:25:11,622 --> 00:25:14,800
-the chat as well. I wanna shout
-out to Abbey Perini because she
+chat as well. I wanna shoutout
+to Abbey Perini because she
 
 482
 00:25:14,801 --> 00:25:18,000
@@ -3043,17 +2955,13 @@ like, "After midnight, put up
 
 483
 00:25:18,000 --> 00:25:22,700
-this in your profile. So, Abbey
+this in your profile." So, Abbey
 has been an amazing observer of
 
-484
-00:25:22,700 --> 00:25:23,861
-Kirk Day, and
-
 485
-00:25:23,862 --> 00:25:26,000
-I could not have asked for
-anything better.
+00:25:22,700 --> 00:25:26,000
+Kirk Day, and I could not have
+asked for anything better.
 
 486
 00:25:26,000 --> 00:25:29,300
@@ -3067,8 +2975,7 @@ Bekah: We don't want breakout
 
 486
 00:25:31,500 --> 00:25:32,700
-where are we breaking out
-to?
+where are we breaking out to?
 
 487
 00:25:33,000 --> 00:25:35,000
@@ -3078,7 +2985,7 @@ Dan: I was trying to turn off the
 487
 00:25:34,300 --> 00:25:37,700
 Bekah: Will the real slim Kirk
-please stand up. Yes. Oh, my
+please stand up? Yes. Oh, my
 
 488
 00:25:37,700 --> 00:25:42,300
@@ -3111,21 +3018,21 @@ Joke.
 494
 00:25:48,500 --> 00:25:50,700
 Dan: I don't -- I'm not -- we
-just talk about [unintelligible]
+just talk about for --
 
 492
 00:25:50,700 --> 00:25:52,586
-for. I don't know jokes. I
+before. I don't know jokes. I
 can't remember them.
 
 494
 00:25:52,586 --> 00:25:56,457
 Bekah: All right. I'll tell my
-joke. Have you all [??] [laughs]
+joke. Have you all [laughs]
 
 495
 00:25:56,457 --> 00:25:57,146
-don't want about pizza?
+[inaudible] about pizza?
 
 496
 00:25:59,916 --> 00:26:00,936
@@ -3301,7 +3208,7 @@ What?" She, like,
 526
 00:27:27,936 --> 00:27:31,000
 tries to, like, it's a riddle.
-[laughs] You are, right? Like --
+[Laughs] You are, right? Like --
 
 527
 00:27:31,000 --> 00:27:32,000
@@ -3310,7 +3217,7 @@ do it?
 
 527
 00:27:31,500 --> 00:27:35,000
-Dan: No! No. No-
+Dan: No. No. No-
 
 528
 00:27:35,000 --> 00:27:35,700
@@ -3364,7 +3271,7 @@ the challenge.
 534
 00:27:59,297 --> 00:28:02,477
 Dan: That's not a -- mm-mm.
-It's not a joke.
+That is not a joke.
 
 535
 00:28:02,656 --> 00:28:05,777
@@ -3393,12 +3300,12 @@ everybody aspires to?
 540
 00:28:14,500 --> 00:28:20,656
 Dan: Oh, wait. Kirk here. Okay.
-Well, according to
+Well, according to Kirk, one
 
 538
 00:28:20,656 --> 00:28:23,300
-Kirk, one minute left. So, yeah.
-We'll see.
+minute left. So, yeah. We'll
+see.
 
 539
 00:28:23,300 --> 00:28:24,500
@@ -3456,14 +3363,13 @@ Bekah: Yeah, no. We --
 Dan: Avoid my ridiculousness.
 
 548
-00:28:50,000 --> 00:28:52,842
+00:28:50,000 --> 00:28:53,300
 Bekah: Joe, yes. We do need a
-scoreboard. Maybe
+scoreboard. Maybe that will be
 
 549
-00:28:52,842 --> 00:28:54,700
-that will be next month monthly
-challenge --
+00:28:53,300 --> 00:28:54,700
+next month monthly challenge --
 
 550
 00:28:53,700 --> 00:28:55,300
@@ -3512,8 +3418,8 @@ me.
 
 554
 00:29:20,352 --> 00:29:24,001
-Dan: Hmm. How about a select
-button that just announces the
+Dan: Hmm. How about a Slack
+button that just announces that
 
 555
 00:29:24,001 --> 00:29:24,571
@@ -3525,8 +3431,8 @@ Bekah: Everybody-
 
 557
 00:29:26,200 --> 00:29:29,000
-Dan: That- that- that I'm doubt-
-that I'm doubt-
+Dan: That- that- that I'm- that
+I'm-
 
 558
 00:29:26,300 --> 00:29:30,500
@@ -3543,31 +3449,31 @@ It's fine.
 Dan: Hm.
 
 559
-00:29:35,000 --> 00:29:38,000
+00:29:35,000 --> 00:29:39,000
 Bekah: Kirk just preparing to be
-up here.
+up here. Yeah, he probably --
 
 559
-00:29:38,000 --> 00:29:38,861
-Yeah, he probably -- sorry,
-Kirk, we're sorry that you
+00:29:39,000 --> 00:29:41,300
+sorry, Kirk, we're sorry that
+you have to prepare for us
 
 561
-00:29:40,616 --> 00:29:41,500
-have to prepare for us [laughs].
+00:29:41,300 --> 00:29:41,500
+[laughs].
 
 562
 00:29:41,500 --> 00:29:42,000
 Kirk: Yeah.
 
 563
-00:29:42,300 --> 00:29:44,277
+00:29:42,300 --> 00:29:44,500
 Bekah: We were trying to send a
-drone that would
+drone that would just go scoop
 
 563
-00:29:44,277 --> 00:29:44,700
-just go scoop up Kirk-
+00:29:44,500 --> 00:29:45,000
+up Kirk-
 
 564
 00:29:44,700 --> 00:29:46,000
@@ -3611,13 +3517,10 @@ if there's a bad echo. Cuz I'm
 just gonna play it over the
 speakers. And because Zoom is
 
-571
-00:30:07,000 --> 00:30:07,926
-actually -- usually
-
 572
-00:30:07,926 --> 00:30:09,000
-pretty good at that. Like-
+00:30:07,000 --> 00:30:09,000
+actually -- usually pretty good
+at that. Like-
 
 573
 00:30:09,000 --> 00:30:10,500
@@ -3625,28 +3528,27 @@ Bekah: One headphone in your ear
 and one headphone in my ear.
 
 574
-00:30:10,500 --> 00:30:11,737
+00:30:10,500 --> 00:30:13,000
 Dan: I mean, if that's all we
-have to
+have to do, I -- you know, we
 
 573
-00:30:11,737 --> 00:30:15,247
-do, I -- you know, we can do
-AirPods or something. But like,
+00:30:13,000 --> 00:30:17,300
+can do AirPods or something. But
+like, that'll be annoying. I
 
 574
-00:30:15,247 --> 00:30:19,507
-that'll be annoying. I have --
-I'm trying to think if there's
+00:30:17,300 --> 00:30:23,000
+have -- I'm trying to think if
+there's any other ... solution.
 
 575
-00:30:19,507 --> 00:30:25,300
-any other ... solution. But
-literally, this is the first
+00:30:23,000 --> 00:30:27,500
+But literally, this is the first
+time I've ever sat next to
 
 576
-00:30:25,300 --> 00:30:28,000
-time I've ever sat next to
+00:30:27,500 --> 00:30:28,000
 somebody-
 
 577
@@ -3723,13 +3625,13 @@ Bekah: I meant-
 Dan: I would be sad about that.
 
 588
-00:30:59,700 --> 00:31:02,636
-Bekah: -just have my
-computer, and log on, and I
+00:30:59,700 --> 00:31:03,300
+Bekah: -just have my computer,
+and log on, and I would sit
 
 587
-00:31:02,636 --> 00:31:04,000
-would sit here-
+00:31:03,300 --> 00:31:04,000
+here-
 
 588
 00:31:03,500 --> 00:31:05,800
@@ -3738,8 +3640,8 @@ like you ended up getting a --
 
 589
 00:31:04,000 --> 00:31:06,477
-Bekah: -but just so I
-could put the sound in my ear.
+Bekah: -but just so I could put
+the sound in my ear.
 
 588
 00:31:06,477 --> 00:31:08,000
@@ -3830,14 +3732,10 @@ like ... I dunno. I feel
 like back in the day, they used
 to have a lot of cool things of
 
-604
-00:31:52,000 --> 00:31:52,796
-where you'd
-
 605
-00:31:52,797 --> 00:31:55,076
-split the, you know? I probably,
-honestly have --
+00:31:52,000 --> 00:31:55,076
+where you'd split the, you know?
+I probably, honestly have --
 
 606
 00:31:55,076 --> 00:31:56,700
@@ -3888,7 +3786,7 @@ Bekah: I said --
 611
 00:32:08,700 --> 00:32:11,000
 Dan: But those were recorded,
-you know? they were like --
+you know? They were like --
 
 612
 00:32:11,000 --> 00:32:12,000
@@ -3896,8 +3794,8 @@ Bekah: Old people?
 
 612
 00:32:12,000 --> 00:32:16,000
-Dan: No. For like cool kids in
-high school that listened to
+Dan: No. Fo-for like cool kids
+in high school that listened to
 
 613
 00:32:16,000 --> 00:32:17,700
@@ -3958,7 +3856,7 @@ Dan: Hey! There you are
 
 618
 00:32:33,500 --> 00:32:34,000
-Bekah: Kirk!!!
+Bekah: Kirk!
 
 619
 00:32:35,700 --> 00:32:37,500
@@ -3978,28 +3876,25 @@ Dan: It's Kirk!
 Kirk: I, like, feel watching the
 stream while I was getting ready.
 
-619
-00:32:43,500 --> 00:32:45,000
-And then,
-
 620
-00:32:45,071 --> 00:32:47,531
-there was a moment where I'm
-like, "This is -- there's a lot
+00:32:43,500 --> 00:32:46,500
+And then, there was a moment
+where I'm like, "This is --
 
 622
-00:32:47,531 --> 00:32:51,056
-of going on here. I don't know-
-I don't know where I fit in.
+00:32:46,500 --> 00:32:50,000
+there's a lot of going on here.
+I don't know- I don't know where
 
 623
-00:32:52,000 --> 00:32:54,581
-I don't have any jokes. And
+00:32:50,000 --> 00:32:55,500
+I fit in. I don't have any
+jokes. And I don't have, like,
 
 624
-00:32:54,582 --> 00:32:59,000
-I don't have, like, any jokes
-[inaudible] rule formats. So --
+00:32:55,500 --> 00:32:59,000
+any jokes [inaudible] rule
+formats." So --
 
 625
 00:32:59,000 --> 00:33:01,000
@@ -4046,7 +3941,7 @@ you're here.
 
 628
 00:33:27,500 --> 00:33:28,000
-Kirk: I just -- 
+Kirk: I just --
 
 629
 00:33:28,000 --> 00:33:30,326
@@ -4076,12 +3971,12 @@ Dan: Oh, god.
 Bekah: Let's start.
 
 634
-00:33:39,000 --> 00:33:40,017
+00:33:39,000 --> 00:33:41,000
 Dan: All right. Everybody else
+has said there's no audio
 
 631
-00:33:40,017 --> 00:33:42,000
-has said there's no audio
+00:33:41,000 --> 00:33:42,000
 issues.
 
 632
@@ -4113,12 +4008,12 @@ Bekah: Yeah.
 635
 00:33:51,700 --> 00:33:55,346
 Kirk: I did -- this entire day,
-I've just been seeing threats
+I've just been seeing threads
 
 637
 00:33:55,346 --> 00:33:58,000
 ongoing. I don't remember
-talking though [??]. No.
+talking though. No.
 
 638
 00:33:58,000 --> 00:34:00,700
@@ -4160,7 +4055,7 @@ about any of this. I woke up,
 
 644
 00:34:19,500 --> 00:34:23,186
-I saw, I just assumed Slack
+I saw it, I just assumed Slack
 wasn't working.
 
 646
@@ -4240,7 +4135,7 @@ Kirk to distinguish himself
 656
 00:34:54,597 --> 00:34:57,597
 from other people." But it
-wasn't even about me, which I
+wasn't even about me. Which I
 
 657
 00:34:57,597 --> 00:34:58,000
@@ -4275,7 +4170,7 @@ love Kirk.
 
 663
 00:35:09,626 --> 00:35:10,500
-Dan: Yap. It's true.
+Dan: Yep. It's true.
 
 661
 00:35:10,700 --> 00:35:11,000
@@ -4298,17 +4193,17 @@ Valentine's day, cuz they're
 
 665
 00:35:20,500 --> 00:35:21,027
-like, "What is
+like, "What is this? It's
 
 665
-00:35:21,027 --> 00:35:24,657
-this? It's a commercial holiday
-to sell us chocolate, and flowers,
+00:35:21,027 --> 00:35:25,500
+a commercial holiday to sell us
+chocolate, and flowers, and cars."
 
 666
-00:35:24,717 --> 00:35:28,700
-and cars. And -- but it's also a
-day to, like, remind you to stop
+00:35:25,500 --> 00:35:28,700
+And -- but, it's also a day to,
+like, remind you to stop
 
 667
 00:35:28,700 --> 00:35:33,000
@@ -4415,14 +4310,14 @@ really into you being fired.
 Like, as much as like Kirk Day,
 
 681
-00:36:18,700 --> 00:36:21,507
+00:36:18,700 --> 00:36:22,700
 like, on their tier list of
-events, Kirk
+events, Kirk Day, Bekah being
 
 682
-00:36:21,507 --> 00:36:26,000
-Day, Bekah being fired, that's
-what the people want.
+00:36:22,700 --> 00:36:26,000
+fired, that's what the people
+want.
 
 683
 00:36:26,967 --> 00:36:29,700
@@ -4434,21 +4329,18 @@ fired [Bekah and Dan laugh]?
 Kirk: I dunno.
 
 685
-00:36:31,000 --> 00:36:32,126
+00:36:31,000 --> 00:36:33,000
 Bekah: I don't even know what to
+do. I'm gonna have to, like,
 
 684
-00:36:32,126 --> 00:36:35,487
-do. I'm gonna have to, like,
+00:36:33,000 --> 00:36:38,000
 think about this very hard on my
+two and a half hour drive home.
 
 685
-00:36:35,487 --> 00:36:39,700
-two and a half hour drive home.
+00:36:38,000 --> 00:36:39,927
 Why everybody wants me to be
-
-686
-00:36:39,700 --> 00:36:39,927
 fired?
 
 686
@@ -4495,8 +4387,8 @@ Bekah: Listen, my --
 
 694
 00:37:07,000 --> 00:37:09,700
-The second time it happened,
-let's fire.
+Kirk: The second time it
+happened, less [??] fire.
 
 693
 00:37:10,000 --> 00:37:13,000
@@ -4522,7 +4414,7 @@ coding? I didn't -- I was have
 
 697
 00:37:26,500 --> 00:37:26,657
-to -- 
+to --
 
 697
 00:37:26,657 --> 00:37:28,500
@@ -4530,22 +4422,18 @@ Bekah: I mean, I can tell that
 one, but then people always feel
 
 698
-00:37:28,700 --> 00:37:29,000
-awkward.
-
-698
-00:37:29,146 --> 00:37:32,027
-Cuz, like, when someone asks you
-how you got into coding and you
+00:37:29,146 --> 00:37:31,500
+awkward. Cuz, like, when someone
+asks you how you got into coding
 
 699
-00:37:32,027 --> 00:37:34,757
-use the word vagina, they're
-suddenly like, all weird about
+00:37:31,500 --> 00:37:34,500
+and you use the word vagina,
+they're suddenly like, all weird
 
 700
-00:37:34,757 --> 00:37:34,800
-it.
+00:37:34,500 --> 00:37:34,800
+about it.
 
 701
 00:37:34,800 --> 00:37:37,000
@@ -4699,7 +4587,7 @@ Dan: What do you call that words
 of room? What's the word for-
 
 720
-00:38:25,700 --> 00:38:28,500 
+00:38:25,700 --> 00:38:28,500
 Kirk: -you've said as
 [inaudible] house-
 
@@ -4759,7 +4647,7 @@ and I went two weeks -- last
 
 727
 00:38:47,700 --> 00:38:48,987
-week -- when was I gone?
+week? When was I gone?
 
 728
 00:38:48,987 --> 00:38:50,500
@@ -4780,19 +4668,18 @@ tree house like Airbnb-
 Bekah: Oh, nice.
 
 730
-00:38:54,326 --> 00:38:56,515
+00:38:54,326 --> 00:38:57,515
 Dan: -it's like a newly built
-thing
+thing that was, like, well way
 
 731
-00:38:56,516 --> 00:38:59,186
-that was, like, well way raised
-up in the trees and stuff. It
+00:38:57,516 --> 00:39:00,000
+raised up in the trees and
+stuff. It was really cool. Yeah.
 
 733
-00:38:59,186 --> 00:39:01,646
-was really cool. Yeah. Highly
-recommend.
+00:39:00,000 --> 00:39:01,646
+Highly recommend.
 
 734
 00:39:02,666 --> 00:39:05,697
@@ -4895,8 +4782,8 @@ history of bikes,
 
 752
 00:39:49,061 --> 00:39:52,751
-there was like a massive
-upsurge in popularity with women
+there was like a massive upsurge
+in popularity with women
 
 753
 00:39:53,112 --> 00:39:55,811
@@ -4915,21 +4802,18 @@ reactionary thing so that
 
 757
 00:40:02,351 --> 00:40:04,000
-people, they were, like,
+people -- they were, like,
 published articles about, like,
 
 758
-00:40:04,000 --> 00:40:05,862
-the bicycle. Is it
+00:40:04,000 --> 00:40:10,000
+the bicycle. Is it ruining your
+woman [laughs] to get them stay
 
 758
-00:40:05,862 --> 00:40:11,700
-ruining your woman [laughs] to
-get them stay home again? Is
-
-759
-00:40:11,700 --> 00:40:13,322
-that how that goes?
+00:40:10,000 --> 00:40:11,700
+home again? Is that how that
+goes?
 
 760
 00:40:13,322 --> 00:40:16,700
@@ -4959,7 +4843,8 @@ Kirk: You can't or you don't?
 
 767
 00:40:25,000 --> 00:40:26,000
-Dan: You don't know how?
+Dan: You don't know how? Or you
+can't?
 
 765
 00:40:27,251 --> 00:40:27,700
@@ -4989,23 +4874,19 @@ Kirk: So, you did know how to
 ride a bike.
 
 770
-00:40:35,000 --> 00:40:37,870
+00:40:35,000 --> 00:40:38,500
 Bekah: I don't know. I mean, do
-you know how if
+you know how if you keep falling
 
 769
-00:40:37,871 --> 00:40:41,396
-you keep falling off? I had a
-bunch of stitches in my elbow.
+00:40:38,500 --> 00:40:42,000
+off? I had a bunch of stitches
+in my elbow. See? There's still
 
 770
-00:40:41,396 --> 00:40:43,677
-See? There's still scar there. I
-don't think you can see that on
-
-771
-00:40:43,677 --> 00:40:44,000
-screen.
+00:40:42,000 --> 00:40:44,000
+scar there. I don't think you
+can see that on screen.
 
 772
 00:40:44,000 --> 00:40:44,700
@@ -5032,12 +4913,11 @@ Kirk: Not a contest.
 772
 00:40:51,000 --> 00:40:54,356
 Bekah: I once ran into a pole
-while riding on a bicycle
+while riding on a bicycle.
 
 773
 00:40:57,000 --> 00:40:57,700
-[silence]. I don't ride
-bicycles.
+I don't ride bicycles.
 
 774
 00:40:57,700 --> 00:41:01,000
@@ -5164,43 +5044,40 @@ skateboard, and I was like,
 "This is gonna break my hip."
 
 789
-00:41:47,291 --> 00:41:49,226
+00:41:47,291 --> 00:41:49,900
 Dan: It's gonna [inaudible].
-Yeah. I
+Yeah. I was just worried about
 
 790
-00:41:49,226 --> 00:41:50,000
-was just worried about my
-[inaudible] --
+00:41:49,900 --> 00:41:50,000
+my [inaudible] --
 
 791
-00:41:50,000 --> 00:41:52,700
+00:41:50,000 --> 00:41:53,000
 Bekah: No sled riding. I- I once
-almost broke my
+almost broke my hip sled riding.
 
 792
-00:41:52,700 --> 00:41:55,527
-hip sled riding. I had to go to
-the emergency room. It wasn't
+00:41:53,000 --> 00:41:56,300
+I had to go to the emergency
+room. It wasn't broken, but gave
 
 793
-00:41:55,527 --> 00:41:58,000
-broken, but gave me lifelong
-problems.
+00:41:56,300 --> 00:41:58,000
+me lifelong problems.
 
 794
 00:41:58,500 --> 00:41:59,000
 Kirk: That's a lot.
 
 795
-00:41:58,700 --> 00:42:00,806
+00:41:58,700 --> 00:42:01,000
 Bekah: When I was- I was on a
-mattress. I
+mattress. I sled rode on a
 
 794
-00:42:00,806 --> 00:42:02,500
-sled rode on a mattress. That
-was a bad idea.
+00:42:01,000 --> 00:42:02,500
+mattress. That was a bad idea.
 
 795
 00:42:02,500 --> 00:42:04,300
@@ -5216,13 +5093,13 @@ Bekah: Well, so --
 Dan: That's a little different.
 
 795
-00:42:05,700 --> 00:42:06,686
-Bekah: I was, like, not
+00:42:05,700 --> 00:42:08,300
+Bekah: I was, like, not good at
+sled riding. And so then these
 
 796
-00:42:06,686 --> 00:42:08,700
-good at sled riding. And so then
-these boys in college-
+00:42:08,300 --> 00:42:08,700
+boys in college-
 
 797
 00:42:08,700 --> 00:42:09,700
@@ -5269,18 +5146,14 @@ Dan: Yeah! Alright. There's -- I
 knew there's more of the story.
 
 801
-00:42:20,300 --> 00:42:21,686
+00:42:20,300 --> 00:42:22,700
 Bekah: -but I was like, "Don't
-go over
+go over the ramp. They promised
 
 800
-00:42:21,686 --> 00:42:22,916
-the ramp. They promised they
-wouldn't go over the ramp and
-
-801
-00:42:22,916 --> 00:42:24,146
-you know what-
+00:42:22,700 --> 00:42:24,146
+they wouldn't go over the ramp
+and you know what-
 
 802
 00:42:24,146 --> 00:42:24,300
@@ -5406,13 +5279,17 @@ riding is picking your spot.
 
 814
 00:43:06,387 --> 00:43:09,356
-Cuz if you go where there's
-like huge ramps or like, I don't
+Cuz if you go where there's like
+huge ramps or like — I don't
 
 815
-00:43:09,356 --> 00:43:11,500
-know where else you crashed, but
-like trees and stuff, you know-
+00:43:09,356 --> 00:43:11,300
+know where else you crashed —
+but like, trees and stuff, you
+
+816
+00:43:11,300 --> 00:43:11,500
+know-
 
 816
 00:43:11,500 --> 00:43:12,500
@@ -5430,7 +5307,7 @@ times [chuckles].
 816
 00:43:13,700 --> 00:43:15,700
 Dan: Yeah, yeah. Well, slides
-are hard to sti- like, they
+are hard to stee- like, they
 
 817
 00:43:15,700 --> 00:43:16,137
@@ -5473,14 +5350,10 @@ multiple times.
 Dan: Yeah. You- you see? You can
 affect like s- like slow gradual
 
-823
-00:43:31,000 --> 00:43:32,935
-turns on
-
 824
-00:43:32,936 --> 00:43:34,300
-sleds. You know what I mean? But
-like --
+00:43:31,000 --> 00:43:34,300
+turns on sleds. You know what I
+mean? But like --
 
 825
 00:43:33,500 --> 00:43:35,000
@@ -5488,13 +5361,9 @@ Bekah: I just [inaudible]
 straight down.
 
 826
-00:43:35,500 --> 00:43:36,700
+00:43:35,500 --> 00:43:38,300
 Dan: What -- I mean, I'm saying,
-you can
-
-825
-00:43:36,700 --> 00:43:38,300
-turn slowly while-
+you can turn slowly while-
 
 826
 00:43:38,300 --> 00:43:38,500
@@ -5502,8 +5371,8 @@ Bekah: Yeah.
 
 827
 00:43:38,500 --> 00:43:39,700
-Dan: you're going
-fast, straight down.
+Dan: you're going fast, straight
+down.
 
 828
 00:43:40,000 --> 00:43:41,500
@@ -5511,18 +5380,17 @@ Bekah: I was [inaudible] in the
 ground.
 
 826
-00:43:40,500 --> 00:43:41,000
+00:43:40,500 --> 00:43:42,000
 Dan: But you have to plan it
-ahead [laughs].
+ahead [laughs]. You have to plan
 
 827
-00:43:41,000 --> 00:43:43,700
-You have to plan it ahead or
-just ditch it, is what
+00:43:42,000 --> 00:43:44,700
+it ahead or just ditch it, is
+what I would -- what I do when I
 
 829
-00:43:43,700 --> 00:43:45,237
-I would -- what I do when I
+00:43:44,700 --> 00:43:45,237
 wanna control.
 
 830
@@ -5633,7 +5501,7 @@ sending poop emojis and they
 
 843
 00:44:27,581 --> 00:44:29,021
-thought of flying. So --
+thought of [inaudible]. So --
 
 844
 00:44:29,021 --> 00:44:31,000
@@ -5672,46 +5540,43 @@ knows this story.
 Dan: I'm alright with that.
 
 849
-00:44:41,700 --> 00:44:42,612
-Bekah: The one morning,
+00:44:41,700 --> 00:44:44,000
+Bekah: The one morning, a couple
+of weeks ago, we were making
 
 850
-00:44:42,641 --> 00:44:46,271
-a couple of weeks ago, we were
-making pancakes and my daughters
+00:44:44,000 --> 00:44:47,000
+pancakes and my daughters
+decided they were gonna make
 
 851
-00:44:46,271 --> 00:44:49,700
-decided they were gonna make
+00:44:47,000 --> 00:44:52,500
 pan-Kirks [chuckles], some
+pancakes that looked like Kirk.
 
 852
-00:44:49,700 --> 00:44:50,561
-pancakes that
-
-852
-00:44:50,561 --> 00:44:54,101
-looked like Kirk. And then
-they argued over who would eat
+00:44:52,500 --> 00:44:54,700
+And then they argued over who
+would eat the pan-Kirk. But
 
 853
-00:44:54,101 --> 00:44:57,072
-the pan-Kirk. But then, it -- we
-only had a little bit of butter
+00:44:54,700 --> 00:44:58,000
+then, it -- we only had a little
+bit of butter left. So there was
 
 854
-00:44:57,072 --> 00:45:00,300
-left. So there was only one
-pan-Kirk and it looked like a
+00:44:58,000 --> 00:45:02,300
+only one pan-Kirk and it looked
+like a tiny baby. So, I think
 
 855
-00:45:00,300 --> 00:45:04,700
-tiny baby. So, I think Gemma ate
-baby pan-Kirk [laughs]. Kirk is
+00:45:02,300 --> 00:45:06,300
+Gemma ate baby pan-Kirk
+[laughs]. Kirk is like this very
 
 856
-00:45:04,700 --> 00:45:08,202
-like this strange [laughs] --
+00:45:06,300 --> 00:45:08,202
+strange [laughs] --
 
 857
 00:45:08,202 --> 00:45:10,000
@@ -5824,8 +5689,8 @@ Bekah: Yeah. That's [inaudible]
 
 874
 00:46:01,300 --> 00:46:02,700
-Dan: So you're not [inaudible]
-you're just bragging at this
+Dan: So you're not [inaudible].
+You're just bragging at this
 
 873
 00:46:02,700 --> 00:46:05,442
@@ -5870,23 +5735,19 @@ anything like that. So I was-
 Kirk: Wait --
 
 881
-00:46:29,000 --> 00:46:30,072
+00:46:29,000 --> 00:46:30,700
 Dan: -just -- I don't have a
-plan for
+plan for this. I was thinking if
 
 880
-00:46:30,072 --> 00:46:32,000
-this. I was thinking if I had
-[chuckles] somebody has a --
-
-881
-00:46:32,000 --> 00:46:33,040
-has- has a good, you
+00:46:30,700 --> 00:46:33,040
+I had [chuckles] somebody has a
+-- has- has a good, you know,
 
 882
 00:46:33,041 --> 00:46:35,862
-know, random question -- or
-Kirk, if you --
+random question -- or Kirk, if
+you --
 
 883
 00:46:35,862 --> 00:46:36,500
@@ -5955,7 +5816,7 @@ Dan: I have that problems too.
 892
 00:47:10,257 --> 00:47:11,700
 Bekah: And it hurts every day
-[laughs]. 
+[laughs].
 
 893
 00:47:11,700 --> 00:47:12,500
@@ -5964,7 +5825,7 @@ right, Dan? You just way too
 
 894
 00:47:12,500 --> 00:47:14,817
-much muscle. 
+much muscle.
 
 893
 00:47:14,817 --> 00:47:17,700
@@ -6063,23 +5924,19 @@ three of those. If you wanna do-
 Kirk: Yeah.
 
 907
-00:47:51,600 --> 00:47:52,976
+00:47:51,600 --> 00:47:53,700
 Dan: -a full workout, then you
-get
+get into the 3D and you get some
 
 906
-00:47:52,976 --> 00:47:55,181
-into the 3D and you get some
+00:47:53,700 --> 00:47:57,700 
 cubes. And, you know, you get
-
-907
-00:47:55,181 --> 00:47:57,386
-some ... other
+some ... other hydron things --
 
 908
-00:47:57,387 --> 00:47:59,000
-hedron [??] things -- oh, man.
-This is where I [inaudible].
+00:47:57,700 --> 00:47:59,000
+oh, man. This is where I
+[inaudible].
 
 909
 00:47:59,000 --> 00:48:00,000
@@ -6087,7 +5944,7 @@ Kirk: This man is clearly --
 
 910
 00:48:00,000 --> 00:48:02,907
-Dan: I almost had it [laughs].
+Dan: I almost said it [laughs].
 
 909
 00:48:02,907 --> 00:48:06,387
@@ -6128,34 +5985,33 @@ and stuff, like-
 Kirk: That's all of them.
 
 917
-00:48:22,300
+00:48:22,300 --> 00:48:24,416
 Dan: -the proper form -- I'm
 saying, I would just kill
 
 916
 00:48:24,416 --> 00:48:26,051
 myself. Like, I would like -- my
-back would throw up or
+back would throw [inaudible] or
 
 917
-00:48:26,051 --> 00:48:28,300
+00:48:26,051 --> 00:48:30,000
 something. You know what I mean?
-I have
+I have [inaudible] literally
 
 918
-00:48:28,300 --> 00:48:32,157
-[inaudible] literally never
-works out. Like, I'm fairly
+00:48:30,000 --> 00:48:33,500
+never works out. Like, I'm
+fairly strong, but Bekah works
 
 919
-00:48:32,157 --> 00:48:35,876
-strong, but Bekah works out all
-the time and it is very strong.
+00:48:33,500 --> 00:48:37,700
+out all the time and it is very
+strong. I feel like a- I feel
 
 921
-00:48:35,876 --> 00:48:39,000
-I feel like a- I feel like a
-bench press is where I-
+00:48:37,700 --> 00:48:39,000
+like a bench press is where I-
 
 922
 00:48:39,000 --> 00:48:39,300
@@ -6180,8 +6036,8 @@ Dan: I dunno- I don't-
 
 926
 00:48:42,700 --> 00:48:44,700
-Bekah: Oh, you for sure could ...
-kill me.
+Bekah: Oh, you for sure could
+... kill me.
 
 924
 00:48:43,101 --> 00:48:46,371
@@ -6209,17 +6065,13 @@ Dan: You know what I mean?
 [Laughs] Then it's just like --
 
 927
-00:48:51,700 --> 00:48:52,791
-and then it's ... you know?
+00:48:51,700 --> 00:48:55,500
+and then it's ... you know? But
+like, any of the ones that like
 
 927
-00:48:53,632 --> 00:48:58,000
-But like, any of the ones that
-like requires skill? I mean,
-
-928
-00:48:58,000 --> 00:48:58,300
-she's-
+00:48:55,500 --> 00:48:58,300
+requires skill? I mean, she's-
 
 928
 00:48:58,461 --> 00:49:00,000
@@ -6258,14 +6110,13 @@ somebody who doesn't ever work
 out.
 
 931
-00:49:06,700 --> 00:49:09,561
+00:49:06,700 --> 00:49:09,700
 Kirk: What I wanna know is who
-wins in cycling. I
+wins in cycling. I think you
 
 932
-00:49:09,561 --> 00:49:10,882
-think you could have an edge
-there.
+00:49:09,700 --> 00:49:10,882
+could have an edge there.
 
 933
 00:49:11,722 --> 00:49:12,300
@@ -6318,7 +6169,8 @@ Bekah: Oh.
 
 938
 00:49:28,400 --> 00:49:29,700
-Dan: -they have like team for competition, you know, as well.
+Dan: -they have like team for
+competition, you know, as well.
 
 939
 00:49:29,700 --> 00:49:33,700
@@ -6345,7 +6197,7 @@ the two of you ... jokes? Ooh.
 
 942
 00:49:45,500 --> 00:49:48,000
-Bekah: Ha-ha. Kirk.
+Bekah: Ha-ha. Grrr.
 
 942
 00:49:49,000 --> 00:49:51,237
@@ -6354,7 +6206,7 @@ wise?
 
 943
 00:49:51,806 --> 00:49:54,626
-Dan: No, Joe, Bekah would win at
+Dan: No, Joe. Bekah would win at
 push-ups easily.
 
 944
@@ -6373,12 +6225,12 @@ right?
 
 946
 00:50:00,987 --> 00:50:03,447
-Kirk: Yeah. But I don't do like
-the full ones. I'm doing like
+Kirk: Yeah. But I don't do,
+like, the full ones. I'm doing
 
 947
 00:50:03,447 --> 00:50:04,500
-incline. No shame.
+like incline. No shame.
 
 948
 00:50:05,847 --> 00:50:08,500
@@ -6409,7 +6261,7 @@ Bekah: Oh, yeah-
 
 954
 00:50:14,700 --> 00:50:15,500
-Dan: -from bending back. 
+Dan: -from bending back.
 
 955
 00:50:14,800 --> 00:50:16,000
@@ -6492,24 +6344,23 @@ comment?
 Bekah: Na- no.
 
 968
-00:50:48,500 --> 00:50:49,931
+00:50:48,500 --> 00:50:50,000
 Dan: Nick just says, "I saw
-someone
+someone mountain biking on a
 
 967
-00:50:49,931 --> 00:50:52,481
-mountain biking on a unicycle in
-a forest outside of Montreal. I
+00:50:50,000 --> 00:50:52,700
+unicycle in a forest outside of
+Montreal. I wave to them and
 
 968
-00:50:52,481 --> 00:50:55,000
-wave to them and they fell. I
-laughed."
+00:50:52,700 --> 00:50:55,000
+they fell. I laughed."
 
 969
 00:50:55,700 --> 00:50:58,000
-Bekah: [All laugh] That's the
-joker of a true story.
+Bekah: [All laugh] That's like
+a joker, but true story.
 
 970
 00:50:57,000 --> 00:50:58,000
@@ -6532,21 +6383,18 @@ Dan: Oh, man. [Inaudible]. I
 just imagine them like doing a
 
 969
-00:51:07,000 --> 00:51:08,231
-jump [Bekah chuckles] on
+00:51:07,000 --> 00:51:11,000
+jump [Bekah chuckles] on a
+unicycle, waving to Nick, and
 
 970
-00:51:08,231 --> 00:51:13,452
-a unicycle, waving to Nick, and
+00:51:11,000 --> 00:51:14,500 
 then, like, seeing them veer off
+into a tree and yelling "Sacré
 
 971
-00:51:13,452 --> 00:51:15,492
-into a tree and yelling "Sacré
+00:51:14,500 --> 00:51:16,000
 bleu," or something like that
-
-972
-00:51:15,492 --> 00:51:16,000
 [laughs].
 
 972
@@ -6560,32 +6408,34 @@ Parkour!"
 
 973
 00:51:19,001 --> 00:51:21,072
-Bekah: Oh, my gosh. My kids
-love that.
+Bekah: Oh, my gosh. My kids love
+that.
 
 974
 00:51:22,512 --> 00:51:23,500
 Kirk: Then, it'll away. No --
 
 975
-00:51:23,500 --> 00:51:26,001
+00:51:23,500 --> 00:51:24,700
 Bekah: A mountain bike unicycle?
-I didn't even know it was a thing.
+
+00:51:24,700 --> 00:51:25,500
+Dan: Yeah, yeah, yeah. You know
+what?
+
+00:51:25,000--> 00:51:26,001
+Bekah: I didn't even know it was
+a thing.
 
 976
-00:51:24,500 --> 00:51:25,700
-Dan: Yeah, yeah, yeah. No. I've
-don't -- I've seen -- I've- I've
+00:51:26,001 --> 00:51:28,500
+Dan: I've- I've seen those for
+sure. A-and, like, the people
 
 977
-00:51:25,700 --> 00:51:29,000
-seen those for sure. A-and,
-like, the people do, like,
-
-977
-00:51:29,000 --> 00:51:32,000
-insane things on them. I've-
-I've seen them once. Oh,
+00:51:28,500 --> 00:51:32,000
+do, like, insane things on them.
+I've- I've seen them once. Oh,
 
 978
 00:51:32,000 --> 00:51:34,500
@@ -6599,7 +6449,7 @@ more, let me do --
 
 981
 00:51:37,000 --> 00:51:39,700
-Kirk: I want to -- you know, on 
+Kirk: I want to -- you know, on
 Spiderman, when they tell him
 
 982
@@ -6618,22 +6468,21 @@ Dan: Yeah.
 983
 00:51:42,600 --> 00:51:45,000
 Kirk: -so cool." I want to be
-on, like, both ends
+on, like, both ends of that. I
 
 984
-00:51:45,000 --> 00:51:47,500
-of that. I wanna be the person
-saying do the flip and
+00:51:45,000 --> 00:51:48,300
+wanna be the person saying do
+the flip and then someone else
 
 985
-00:51:47,500 --> 00:51:51,300
-then someone else does the flip.
-And someone says to me, I wanna
+00:51:48,300 --> 00:51:51,700
+does the flip. And someone says
+to me, I wanna be able to do the
 
 986
-00:51:51,300 --> 00:51:53,000
-be able to do the flip in
-that moment.
+00:51:51,700 --> 00:51:53,000
+flip in that moment.
 
 987
 00:51:52,500 --> 00:51:53,500
@@ -6752,7 +6601,7 @@ daughter's weddings [??]
 1002
 00:52:41,500 --> 00:52:45,000
 Dan: [Inaudible]. I don't know.
-No, I just -- I'm not very
+The -- I just -- I'm not very
 
 1003
 00:52:45,000 --> 00:52:47,757
@@ -6761,7 +6610,7 @@ it's- it's a known fact.
 
 1004
 00:52:47,757 --> 00:52:49,000
-Bekah: Haikus, Kirk. 
+Bekah: Haikus, Kirk.
 
 1005
 00:52:49,000 --> 00:52:50,000
@@ -6807,11 +6656,11 @@ Kirk: One day --
 1007
 00:53:02,697 --> 00:53:05,500
 Bekah: You may be able to find
-all three of our poetry online.
+all three of our poetry online,
 
 1008
 00:53:05,500 --> 00:53:08,300
-If you search hard enough
+if you search hard enough
 [Bekah and Dan laugh].
 
 1009
@@ -6844,32 +6693,28 @@ knows. So, I'm like, "Give me a
 weird ones like a shiver or
 
 1015
-00:53:23,700 --> 00:53:25,601
+00:53:23,700 --> 00:53:26,700
 something like that." Great. And
-then I
+then I met the -- I saw someone
 
 1015
-00:53:25,601 --> 00:53:29,771
-met the -- I saw someone who had
-the murder of crows, and I was
+00:53:26,700 --> 00:53:32,500
+who had the murder of crows, and
+I was like, "Boring." I really
 
 1016
-00:53:29,771 --> 00:53:34,500
-like, "Boring." I really judged
-them about that. But my
-
-1017
-00:53:34,500 --> 00:53:38,351
+00:53:32,500 --> 00:53:37,700
+judged them about that. But my
 website's gone. So [all laugh].
-I don't know what happened
 
 1017
-00:53:38,351 --> 00:53:42,000
-to it. WordPress was just like,
-"You don't do enough."
+00:53:37,700 --> 00:53:39,700
+I don't know what happened to
+it. WordPress was just like,
 
-1018
-00:53:42,000 --> 00:53:43,000
+1017
+00:53:39,700 --> 00:53:43,000
+"You don't do enough."
 [Inaudible].
 
 1019
@@ -6923,7 +6768,7 @@ university used it. Eclipse --
 
 1026
 00:54:19,436 --> 00:54:20,000
-no. 
+no.
 
 1027
 00:54:20,000 --> 00:54:20,817
@@ -6961,8 +6806,8 @@ Kirk: It was --
 
 1030
 00:54:31,947 --> 00:54:34,000
-Bekah: I wanna do yoga with
-the goat too.
+Bekah: I wanna do yoga with the
+goat too.
 
 1031
 00:54:34,000 --> 00:54:34,500
@@ -6980,8 +6825,8 @@ videos. And as somebody who,
 
 1034
 00:54:42,447 --> 00:54:45,500
-like -- I see goats every day,
-goats poop.
+like -- I see goats every day.
+Goats poop.
 
 1035
 00:54:45,500 --> 00:54:46,257
@@ -6997,8 +6842,8 @@ Kirk: Goats poop.
 
 1038
 00:54:49,700 --> 00:54:52,500
-Dan: Is the goat doing and yoga
-too or is the goat just like --
+Dan: Is the goat doing yoga too
+or is the goat just like --
 
 1037
 00:54:52,500 --> 00:54:56,000
@@ -7062,28 +6907,24 @@ Flash. And ... there was another
 one that I didn't use very much,
 
 1047
-00:55:19,000 --> 00:55:21,387
+00:55:19,000 --> 00:55:22,500
 like a more of designing one.
-But
+But ... yeah. I was in
 
 1049
-00:55:21,387 --> 00:55:24,000
-... yeah. I was in Dreamweavers,
-Fireworks -- and, like,
+00:55:22,500 --> 00:55:24,500
+Dreamweavers, Fireworks -- and,
+like, Dreamweaver was actually
 
 1051
-00:55:24,000 --> 00:55:27,500
-Dreamweaver was actually really
-good. Even not using the, like,
-
-1052
-00:55:28,000 --> 00:55:28,435
-generated
+00:55:24,500 --> 00:55:29,000
+really good. Even not using the,
+like, generated stuff, but it
 
 1053
-00:55:28,436 --> 00:55:30,500
-stuff, but it was a good, like,
-code editor. Like, I used it-
+00:55:29,000 --> 00:55:30,500
+was a good, like, code editor.
+Like, I used it-
 
 1054
 00:55:30,500 --> 00:55:30,700
@@ -7097,7 +6938,7 @@ editor for -- I dunno. I dunno
 1056
 00:55:34,887 --> 00:55:35,500
 when I stopped. But like a long
-time.
+time. [Inaudible].
 
 1057
 00:55:35,700 --> 00:55:39,327
@@ -7116,7 +6957,7 @@ director-
 
 1061
 00:55:44,000 --> 00:55:44,700
-Kirk: F-tracks [??].
+Kirk: [Inaudible] tracks [??].
 
 1062
 00:55:45,000 --> 00:55:46,887
@@ -7144,7 +6985,7 @@ had like textbooks on HTML and
 
 1067
 00:56:02,500 --> 00:56:04,700
-CSS. So then we went over those
+CSS. So, then we went over those
 things, and like, "All right, I
 
 1068
@@ -7203,7 +7044,7 @@ apparently very popular, but
 1080
 00:56:38,077 --> 00:56:41,300
 it's the first time I heard it.
-Bekah, don't ruin it.
+Bekah, don't ... ruin it.
 
 1081
 00:56:41,300 --> 00:56:41,500
@@ -7243,7 +7084,7 @@ don't know why.
 1083
 00:56:59,000 --> 00:57:02,757
 Kirk: That was really good.
-Because they can't 'see sharp'.
+Because they can't see sharp.
 
 1084
 00:57:04,166 --> 00:57:05,000
@@ -7289,8 +7130,8 @@ you know, back when like --
 
 1091
 00:57:29,500 --> 00:57:31,996
-Bekah: Well, you're like
-13. You didn't hear anything.
+Bekah: Well, you're like 13. You
+didn't hear of anything.
 
 1092
 00:57:31,996 --> 00:57:34,000
@@ -7317,8 +7158,8 @@ validation I need.
 
 1097
 00:57:42,700 --> 00:57:47,000
-Dan: C++. Does C++ not exist
-anymore?
+Dan: [Inaudible] C++. Does C++
+not exist anymore?
 
 1097
 00:57:47,186 --> 00:57:51,500
@@ -7366,17 +7207,14 @@ It's all Microsoft.
 Dan: Oh, okay.
 
 1101
-00:58:03,572 --> 00:58:04,447
-Kirk: Right? That's this --
+00:58:03,572 --> 00:58:07,500
+Kirk: Right? That's this -- if
+you're in Microsoft, 90% of
 
 1102
-00:58:05,000 --> 00:58:09,000
-if you're in Microsoft, 90% of
-the time you're writing C#.
-
-1103
-00:58:09,000 --> 00:58:14,700
-And C++ is not. C++ is still
+00:58:07,500 --> 00:58:14,700
+the time you're writing C#. And
+C++ is not. C++ is still
 
 1104
 00:58:14,700 --> 00:58:21,700
@@ -7384,18 +7222,18 @@ considered like the lang du jour
 for like high-performance stuff
 
 1106
-00:58:21,700 --> 00:58:27,606
-if you don't wanna get down to
-C, I guess. But I feel like C++
+00:58:21,700 --> 00:58:26,700
+if you don't wanna get, like,
+down to C, I guess. But I feel
 
 1107
-00:58:27,606 --> 00:58:30,500
-dad's favorite thing to do
-is like complain about C++
+00:58:26,700 --> 00:58:29,300
+like C++, their [??] favorite
+thing to do is like complain
 
 1108
-00:58:30,500 --> 00:58:30,700
-[chuckles].
+00:58:29,300 --> 00:58:30,700
+about C++ [chuckles].
 
 1109
 00:58:30,700 --> 00:58:31,000
@@ -7422,62 +7260,58 @@ enough, like, there'll be enough
 
 1112
 00:58:37,871 --> 00:58:40,300
-code written, that there isn't
+code written, then there isn't
 something to complain about.
 
 1114
-00:58:40,782 --> 00:58:44,700
+00:58:40,782 --> 00:58:45,000
 Dan: Like, Emily ... tells
 people -- like, sh- she was a --
 
 1115
-00:58:44,700 --> 00:58:45,700
-on a trip with her grandma
+00:58:45,000 --> 00:58:47,300
+on a trip with her grandma and
+she's like, "Yeah, Dan hates
 
 1116
-00:58:45,700 --> 00:58:49,092
-and she's like, "Yeah, Dan hates
+00:58:47,300 --> 00:58:50,300
 computers." And she knows that,
+like, I do this -- I do this
 
 1117
-00:58:49,092 --> 00:58:51,822
-like, I do this -- I do this
+00:58:50,300 --> 00:58:52,500
 for a living, you know? But it's
+true. [Laughs] I'm like -- I
 
 1118
-00:58:51,822 --> 00:58:54,300
-true. [Laughs] I'm like -- I
+00:58:52,500 --> 00:58:54,700
 just -- she- she didn't
-
-1119
-00:58:54,300 --> 00:58:55,692
 understand -- you know, she's
-like, "What? What does that 
 
 1119
-00:58:55,692 --> 00:58:58,000
+00:58:54,700 --> 00:58:57,500
+like, "What? What does that
 mean?" She's like, "Yeah. Dan
+
+1119
+00:58:57,500 --> 00:58:59,300
 hates computers." I'm like
-
-1120
-00:58:58,000 --> 00:58:59,500
 [laughs] -- cuz she told me a
-story --
 
 1120
-00:58:59,500 --> 00:59:01,961
-cuz I was like, "Oh, yesterday
-I spent like
+00:58:59,300 --> 00:59:01,700
+story -- cuz I was like -- oh,
+yesterday, I spent like three
 
 1121
-00:59:01,961 --> 00:59:05,592
-three hours trying to get ..." I
-almost did it. I almost went
+00:59:01,700 --> 00:59:05,592
+hours trying to get — I almost
+did it. I almost went over a
 
 1122
 00:59:05,592 --> 00:59:11,231
-over a PG-13 again. Ruby to work
-again on my computer. And it was
+PG-13 again — Ruby to work again
+on my computer. And it was
 
 1123
 00:59:11,231 --> 00:59:14,112
@@ -7548,18 +7382,14 @@ that's like [chuckles] what's
 [inaudible] Ruby in, and it was
 
 1134
-00:59:49,500 --> 00:59:52,362
+00:59:49,500 --> 00:59:53,000
 super painful. And I didn't,
-like, look
+like, look at a line of Ruby
 
 1134
-00:59:52,362 --> 00:59:56,000
-at a line of Ruby again for like
-10 years. So ... you know?
-
-1135
-00:59:56,000 --> 00:59:58,092
-Onboarding matters.
+00:59:53,000 --> 00:59:58,092
+again for like 10 years. So ...
+you know? Onboarding matters.
 
 1136
 00:59:58,092 --> 01:00:02,700
@@ -7587,8 +7417,8 @@ do Python stuff all the time
 
 1143
 01:00:11,681 --> 01:00:15,500
-and- and I still mess it up,
-like, getting it to work on my
+and I still mess it up, like,
+getting it to work on my
 
 1144
 01:00:15,500 --> 01:00:18,581
@@ -7680,7 +7510,7 @@ Bekah: Also, I have to go. So
 1157
 01:01:03,000 --> 01:01:06,652
 Dan: Ooh. You have to leave
-at 3? Not 3.30?
+at 3? Not 3.30? Aah.
 
 1158
 01:01:06,652 --> 01:01:08,931
@@ -7746,19 +7576,19 @@ Kirk: I am-
 Dan: That too.
 
 1171
-01:01:38,500 --> 01:01:43,500
+01:01:38,500 --> 01:01:43,700
 Kirk: -I'm happy to provide me
-as a catalyst for
+as a catalyst for the cool
 
 1170
-01:01:43,500 --> 01:01:47,300
-the cool people here. Kirk Day
-is weird. But the people who
+01:01:43,700 --> 01:01:48,000
+people here. Kirk Day is weird.
+But the people who like it are
 
 1171
-01:01:47,300 --> 01:01:52,452
-like it are great [all laugh].
-We're kind of settled on this.
+01:01:48,000 --> 01:01:52,452
+great [all laugh]. We're kind of
+settled on this.
 
 1172
 01:01:53,700 --> 01:01:56,300

--- a/episodes/5_999.srt
+++ b/episodes/5_999.srt
@@ -71,27 +71,27 @@ it was a fun little thing. We
 streamed it live, we had some
 people sharing in the
 
-17
+16
 00:00:53,088 --> 00:00:54,618
 comments, and we thought we
 would share it on the podcast
 
-19
+17
 00:00:54,618 --> 00:01:00,000
 stream as well. So enjoy, and
 next week we will get back to
 
-20
+18
 00:01:00,000 --> 00:01:10,000
 our regular schedule. Hey, we
 were muted the whole time
 
-21
+19
 00:01:10,000 --> 00:01:12,000
 [Bekah laughs]. Bekah, why did
 you do it?
 
-22
+20
 00:01:13,000 --> 00:01:14,000
 Bekah Hawrot Weigel: I was on my
 phone [laughs].
@@ -119,7666 +119,7683 @@ I just did-
 00:01:22,500 --> 00:01:23,200
 Dan: You did a great job.
 
-25
+26
 00:01:23,200 --> 00:01:23,700
 Bekah: -the most amazing-
 
-26
+27
 00:01:24,000 --> 00:01:24,700
 Dan: It was awesome.
 
-27
+28
 00:01:25,000 --> 00:01:26,000
 Bekah: -intro that I've ever
 done.
 
-28
+29
 00:01:26,300 --> 00:01:26,500
 Dan: Yep.
 
-29
+30
 00:01:27,000 --> 00:01:28,000
 Bekah: It's- it's suck
 [chuckles].
 
-27
+31
 00:01:27,700 --> 00:01:29,300
 Dan: It's really good. Yep.
 
-28
+32
 00:01:30,257 --> 00:01:32,000
 Bekah: So here's my not so great
 intro.
 
-29
+33
 00:01:32,000 --> 00:01:32,300
 Dan: We do.
 
-30
+34
 00:01:32,500 --> 00:01:34,156
 Bekah: We are coming here, live
 
-29
+35
 00:01:34,156 --> 00:01:37,816
 from Lakewood, Ohio. We are
 celebrating national Kirk Day or
 
-30
+36
 00:01:37,816 --> 00:01:40,757
 international Kirk Day as we
 more fondly know it at Virtual
 
-31
+37
 00:01:40,757 --> 00:01:41,236
 Coffee.
 
-32
+38
 00:01:41,596 --> 00:01:42,337
 Dan: Intergalactic Kirk Day?
 
-33
+39
 00:01:43,996 --> 00:01:47,147
 Bekah: Intra galactic? Inter- I
 was gonna say disciplinary. That
 
-34
+40
 00:01:47,147 --> 00:01:49,500
 is not the right word.
 Dimensional -- interdimensional
 
-35
+41
 00:01:49,500 --> 00:01:50,057
 Kirk Day.
 
-36
+42
 00:01:50,057 --> 00:01:50,656
 Dan: Yes.
 
-35
+43
 00:01:50,656 --> 00:01:53,027
 Bekah: Because it is preserved
 everywhere, because Kirk is
 
-36
+44
 00:01:53,027 --> 00:01:56,266
 awesome and amazing, and we like
 to celebrate Kirk as much as we
 
-37
+45
 00:01:56,266 --> 00:01:57,000
 can.
 
-38
+46
 00:01:57,300 --> 00:01:58,000
 Dan: Agreed.
 
-39
+47
 00:01:58,500 --> 00:02:01,186
 Bekah: Dan, would you like to
 introduce what international,
 
-38
+48
 00:02:01,277 --> 00:02:03,917
 dimensional, disciplinary Kirk
 day is [chuckles]?
 
-39
+49
 00:02:05,027 --> 00:02:08,000
-Dan: So, was it just a year
-ago?
+Dan: So, was it just a year ago?
 
-40
+50
 00:02:08,000 --> 00:02:09,500
 Bekah: It was a year ago, today.
 
-41
+51
 00:02:08,500 --> 00:02:10,727
 Dan: Two years ago? Today? Yes,
 
-40
+52
 00:02:10,757 --> 00:02:16,300
 Kirk had a tweet where he --
 should I -- how should I read
 
-41
+53
 00:02:16,300 --> 00:02:16,500
 the --
 
-41
+54
 00:02:16,500 --> 00:02:17,800
 Bekah: You should. And put in
 the announcement.
 
-42
+55
 00:02:17,800 --> 00:02:20,501
 Dan: I feel like I should have
 read the- the right text.
 
-43
+56
 00:02:20,501 --> 00:02:21,300
 Bekah: Post it in the chat too.
 
-42
+57
 00:02:21,300 --> 00:02:24,521
 Dan: The- the- the -- this is
 it, right?
 
-43
+58
 00:02:24,521 --> 00:02:24,700
 Bekah: Mm-hmm.
 
-44
+59
 00:02:24,700 --> 00:02:29,500
 Dan: Yeah. So, Kirk tweeted,
 "Today we have achieved the
 
-45
+60
 00:02:29,500 --> 00:02:30,412
 dream. My -- I
 
-44
+61
 00:02:30,412 --> 00:02:32,801
 made a function called Missy
 Elliott that takes data
 
-45
+62
 00:02:32,981 --> 00:02:36,000
 structure, flips it, and
 reverses it. I have ascended."
 
-46
+63
 00:02:36,000 --> 00:02:42,000
 And then, very shortly after
 that, Missy Elliott responded
 
-47
+64
 00:02:42,000 --> 00:02:45,700
 [chuckles], replied on Twitter.
 Actual Missy Elliott. Not- not a
 
-48
+65
 00:02:45,700 --> 00:02:46,000
 fake Missy Elliott.
 
-49
+66
 00:02:46,000 --> 00:02:47,000
 Bekah: The Missy Elliott. That's
 --
 
-50
+67
 00:02:47,500 --> 00:02:50,592
 Dan: And- and said something
 like, yeah, she said, "Wow, I'm
 
-49
+68
 00:02:50,592 --> 00:02:53,366
 humbly -- I'm so humbly
 grateful. Much love to y'all."
 
-50
+69
 00:02:53,366 --> 00:02:56,140
 And that
 
-51
+70
 00:02:56,141 --> 00:02:59,981
 was the beginning of a legend.
 It was- it was really, really
 
-52
+71
 00:02:59,981 --> 00:03:03,700
 awesome [laughs]. And everybody
 saw it, and Kirk's, you know,
 
-53
+72
 00:03:03,700 --> 00:03:03,822
 Twitter ...
 
-53
+73
 00:03:04,542 --> 00:03:10,000
 well, let's see what the -- it-
 it- it Kirk's tweet got a one
 
-54
+74
 00:03:10,300 --> 00:03:13,700
 -- 13.3 thousand retweets
 [laughs] and a hundred --
 
-55
+75
 00:03:13,700 --> 00:03:15,700
 Bekah: A hundred and 70
 [chuckles] -- 70 thousand like.
 
-56
+76
 00:03:15,700 --> 00:03:18,282
 Dan: Yeah. And it's really good
 stuff.
 
-56
+77
 00:03:18,882 --> 00:03:21,117
 Bekah: It -- but not only that,
 not only was it just YouTube,
 
-57
+78
 00:03:21,117 --> 00:03:26,300
 but it expanded. So this was not
 a one day event. It was-
 
-58
+79
 00:03:26,300 --> 00:03:26,700
 Dan: Yeah.
 
-59
+80
 00:03:26,700 --> 00:03:28,000
 Bekah: -it was on Twitter,
 
-59
+81
 00:03:28,000 --> 00:03:33,000
 it was on LinkedIn, it was on
 Reddit. Everybody loves Kirk.
 
-60
+82
 00:03:33,000 --> 00:03:37,151
 Dan: Yes. And we all are --
 already loved Kirk. And this is
 
-61
+83
 00:03:37,151 --> 00:03:40,122
 just a sort of celebration of-
 of the rest of the world,
 
-62
+84
 00:03:40,181 --> 00:03:40,500
 right?
 
-63
+85
 00:03:40,500 --> 00:03:40,700
 Bekah: Yeah.
 
-64
+86
 00:03:40,700 --> 00:03:43,000
 Dan: Be-becoming aware of- of
 the Kirk.
 
-63
+87
 00:03:43,000 --> 00:03:45,822
 Bekah: So maybe we should tell
 our Kirk origin story.
 
-65
+88
 00:03:47,771 --> 00:03:51,000
-Dan: I think that's a great
-idea [laughs]. Do you want me to
+Dan: I think that's a great idea
+[laughs]. Do you want me to
 
-66
+89
 00:03:51,000 --> 00:03:52,000
 go first? Do you wanna go first?
 
-67
+90
 00:03:52,700 --> 00:03:53,300
 Bekah: You go first.
 
-68
+91
 00:03:53,300 --> 00:03:55,122
 Dan: Alright. I don't -- I mean,
 I, like -- I don't have a
 
-68
+92
 00:03:55,122 --> 00:03:56,967
 specific -- I don't remember
 the, like, moment, right? Of- of
 
-69
+93
 00:03:56,967 --> 00:03:58,812
 meeting
 
-70
+94
 00:03:58,812 --> 00:04:03,056
 Kirk. Cuz that was back in the
 time of Virtual Coffee being --
 
-71
+95
 00:04:04,000 --> 00:04:04,500
 Bekah: A tiny baby.
 
-71
+96
 00:04:04,500 --> 00:04:08,097
 Dan: Yes. Very s- a little
 smaller, you know? And so, we
 
-72
+97
 00:04:08,097 --> 00:04:15,700
 had Slack, we had the coffees,
 obviously. But -- and I'm not
 
-74
+98
 00:04:15,700 --> 00:04:20,000
 a person who ... I don't know. I
 don't know a lot of people
 
-75
+99
 00:04:20,000 --> 00:04:20,786
 [laughs]. I don't really
 
-76
+100
 00:04:20,786 --> 00:04:23,307
 -- like, people don't stick in
 my brain until- until we, like,
 
-77
+101
 00:04:23,307 --> 00:04:27,357
 interact. You know what I mean?
 And so, my thing with Kirk was-
 
-78
+102
 00:04:27,387 --> 00:04:29,786
 was really the Hacktoberfest.
 Was really, like, leading up
 
-79
+103
 00:04:29,786 --> 00:04:32,431
 to Hacktoberfest that year. So
 it was two years ago. And ...
 
-81
+104
 00:04:32,431 --> 00:04:38,997
 Bekah and I, you know, we worked
 together and I had known Sarah
 
-82
+105
 00:04:38,997 --> 00:04:42,700
 because she was, you know, like,
 she was already, like, helping
 
-84
+106
 00:04:42,700 --> 00:04:47,201
 with Virtual Coffee and all that
 stuff. And I could just
 
-85
+107
 00:04:47,201 --> 00:04:49,700
 kinda wrote me in, right? For
 Hacktoberfest to, like, help.
 
-86
+108
 00:04:50,000 --> 00:04:50,300
 Bekah: You -- okay.
 
-87
+109
 00:04:50,500 --> 00:04:51,000
 Dan: And I was excited.
 
-88
+110
 00:04:50,700 --> 00:04:52,700
 Bekah: To be fair, you were
 like, "If you need help with
 
-88
+111
 00:04:52,700 --> 00:04:54,641
 anything, let me know."
 
-89
+112
 00:04:54,641 --> 00:04:56,000
 Dan: I may have said that.
 
-90
+113
 00:04:56,000 --> 00:04:59,000
 Bekah: So, if you offer to help,
 you will [chuckles].
 
-91
+114
 00:05:00,000 --> 00:05:02,500
 Dan:  It's true. Yes, most
 people find that about -- out
 
-93
+115
 00:05:02,500 --> 00:05:07,700
 about that eventually. But,
 yeah. So, Kirk was there too,
 
-94
+116
 00:05:07,700 --> 00:05:09,500
-right? And I have, like --
-I, like -- you- you know,
+right? And I have, like -- I,
+like -- you- you know,
 
-95
+117
 00:05:09,500 --> 00:05:11,700
 I'd heard his name or whatever.
 I, you know, we had been --
 
-97
+118
 00:05:11,700 --> 00:05:12,700
 Bekah: But he wasn't Kirk at
 that point.
 
-98
+119
 00:05:13,000 --> 00:05:14,000
 Dan: He was still TK.
 
-99
+120
 00:05:14,000 --> 00:05:14,800
 Bekah: He was still TK.
 
-100
+121
 00:05:15,000 --> 00:05:18,300
 Dan: That's right. He was just
 the mysterious TK, which made
 
-97
+122
 00:05:18,300 --> 00:05:23,500
 me, you know, want to know him
 more, you know? Because, anyway,
 
-98
+123
 00:05:23,500 --> 00:05:24,300
 that has a mysterious name, you
 know? You need to-
 
-100
+124
 00:05:24,300 --> 00:05:25,500
 Bekah: Mm-hmm. Yeah. You need to
 know-
 
-101
+125
 00:05:25,500 --> 00:05:26,000
 Dan: -know more --
 
-102
+126
 00:05:25,700 --> 00:05:27,000
 Bekah: -more of the story.
 
-100
+127
 00:05:27,672 --> 00:05:29,831
-Dan: And, yeah. And then that
--- so that -- it was like that
+Dan: And, yeah. And then that --
+so that -- it was like that
 
-101
+128
 00:05:29,831 --> 00:05:32,569
 September leading up to that
 October. It was a lot of
 
-102
+129
 00:05:32,569 --> 00:05:35,307
 -- Kirk and I were
 
-103
+130
 00:05:35,307 --> 00:05:37,976
--- I mean, I was working on
-the site and that's when the
+-- I mean, I was working on the
+site and that's when the
 
-104
+131
 00:05:37,976 --> 00:05:40,000
 first like this -- the current
 version of the site happened,
 
-106
+132
 00:05:40,000 --> 00:05:42,000
 you know? We made the leap with
 like -- that which has brought
 
-107
+133
 00:05:42,000 --> 00:05:43,107
 us the site
 
-108
+134
 00:05:43,107 --> 00:05:45,357
 for Virtual Coffee where we're
 doing all that stuff. And so, I
 
-109
+135
 00:05:45,357 --> 00:05:49,700
 would be up in the middle of the
 night [chuckles]. And Kirk was
 
-110
+136
 00:05:49,700 --> 00:05:53,000
 usual- usually there too. And we
 would like talk, and, you know,
 
-111
+137
 00:05:53,000 --> 00:05:53,700
 throw ideas back
 
-112
+138
 00:05:53,700 --> 00:05:56,700
 and forth, and think about
 things. And then he was doing a
 
-113
+139
 00:05:56,700 --> 00:06:00,000
 lot of the work on the ... I
 dunno. More --
 
-114
+140
 00:06:00,000 --> 00:06:00,700
 Bekah: Documentation part.
 
-115
+141
 00:06:01,000 --> 00:06:03,000
 Dan: Yeah, social aspect of it,
 the documentation, you know,
 
-115
+142
 00:06:03,000 --> 00:06:04,497
 thinking about how, like, people
 are going
 
-117
+143
 00:06:04,497 --> 00:06:07,976
 to interact with Virtual Coffee,
 and like how we need may-
 
-118
+144
 00:06:08,307 --> 00:06:11,156
 resources for maintainers, and
 what those could look like, and
 
-119
+145
 00:06:11,156 --> 00:06:12,896
 things like that. And so I
 gained a lot of like -- both, it
 
-120
+146
 00:06:12,896 --> 00:06:14,636
 was like fun to
 
-121
+147
 00:06:14,637 --> 00:06:16,947
-hang out with him. And again,
-a lot of, like, respect for
+hang out with him. And again, a
+lot of, like, respect for
 
-122
+148
 00:06:16,947 --> 00:06:21,086
 him, you know, at the same time.
 So- so, yeah. And then after
 
-123
+149
 00:06:21,086 --> 00:06:23,906
 that, it was just like, we're
 just talking every day and had
 
-124
+150
 00:06:24,237 --> 00:06:25,000
 been doing that for-
 
-125
+151
 00:06:26,000 --> 00:06:26,300
 Bekah: Ever?
 
-126
+152
 00:06:26,300 --> 00:06:28,526
 Dan: -the last ... million
 years? I don't -- it feels
 
-125
+153
 00:06:28,526 --> 00:06:29,500
 like -- I don't- I don't know.
 
-126
+154
 00:06:29,500 --> 00:06:30,500
 Bekah: In all the dimension?
 
-127
+155
 00:06:30,500 --> 00:06:33,700
 Dan: You know, in- in multiple
 dimensions. I'd say, if we're
 
-126
+156
 00:06:33,700 --> 00:06:37,500
 gonna use MCU, you know,
 terminology though, Kirk would
 
-127
+157
 00:06:37,500 --> 00:06:41,700
 be like a Nexus being, right?
 So, there's only like, one Kirk-
 
-129
+158
 00:06:42,000 --> 00:06:42,300
 Bekah: Yes. Mm-hmm.
 
-130
+159
 00:06:42,500 --> 00:06:43,500
 Dan: -across the dimensions.
 This --
 
-131
+160
 00:06:43,500 --> 00:06:44,000
 Bekah: Yes.
 
-130
+161
 00:06:44,500 --> 00:06:46,500
 Dan: He's -- our Kirk [??]-
 
-131
+162
 00:06:46,500 --> 00:06:46,700
 Bekah: Our Kirk [??].
 
-131
+163
 00:06:46,700 --> 00:06:47,500
 Dan: -our Kirk [??] is prime
 Kirk in there --
 
-132
+164
 00:06:47,300 --> 00:06:47,700
 Bekah: All the Kirks.
 
-133
+165
 00:06:48,000 --> 00:06:48,700
 Dan: Yeah, yeah, yeah.
 
-134
+166
 00:06:49,000 --> 00:06:49,300
 Bekah: Yeah.
 
-132
+167
 00:06:49,300 --> 00:06:50,000
 Dan: That's what I mean. Yeah.
 
-133
+168
 00:06:50,000 --> 00:06:50,300
 Bekah: For sure.
 
-134
-00:06:50,300 --. 00:06:50,500
+169
+00:06:50,300 --> 00:06:50,500
 Dan: Yeah.
 
-135
+170
 00:06:51,000 --> 00:06:52,076
 Bekah: He's the right Kirk.
 
-134
+171
 00:06:53,547 --> 00:06:54,146
 Dan: Exactly [laughs].
 
-135
+172
 00:06:56,427 --> 00:07:01,400
 Bekah: I will tell my Kirk
 origin story. I don't remember
 
-136
+173
 00:07:01,400 --> 00:07:01,557
 it
 
-137
+174
 00:07:01,557 --> 00:07:05,637
 exactly, but I have known Kirk
 longer than most of the people
 
-138
+175
 00:07:05,637 --> 00:07:08,500
 I've known at Virtual Coffee.
 But back when I knew Kirk, he
 
-140
+176
 00:07:08,500 --> 00:07:13,500
 was like a -- maybe a python
 image or a snake icon?
 
-141
+177
 00:07:13,500 --> 00:07:14,000
 Dan: Oh, yeah, yeah.
 
-142
+178
 00:07:14,500 --> 00:07:14,700
 Bekah: He was not-
 
-143
+179
 00:07:14,700 --> 00:07:15,000
 Dan: Yeah. He --
 
-141
+180
 00:07:15,000 --> 00:07:16,991
 Bekah: -I didn't know his face.
 And then he started coming to
 
-142
+181
 00:07:16,991 --> 00:07:18,836
 Virtual Coffee,
 
-143
+182
 00:07:19,286 --> 00:07:25,646
 and I am really ... like,
 nervous when I meet new people.
 
-144
+183
 00:07:26,036 --> 00:07:30,000
 And then, I was like, "I think
 this person knows me?" And I had
 
-145
+184
 00:07:30,000 --> 00:07:31,500
-to try and figure it out [laughs].
+to try and figure it out
+[laughs].
 
-146
+185
 00:07:31,500 --> 00:07:33,206
 And he would sit in this office,
 like, with this
 
-147
+186
 00:07:33,206 --> 00:07:38,966
 flag behind him, and everybody's
 wearing masks back then when you
 
-148
+187
 00:07:38,966 --> 00:07:43,317
 were on Zoom. And so I'm like,
 "Who is this person that is
 
-149
+188
 00:07:43,317 --> 00:07:47,127
 coming? I'm very nervous about
 them." And then Kirk kept
 
-150
+189
 00:07:47,127 --> 00:07:50,000
 showing up. I'm like, "Okay.
 This is like, this- this person
 
-151
+190
 00:07:50,000 --> 00:07:53,500
 might be my friend. I think
 maybe we're moving into
 
-152
+191
 00:07:53,500 --> 00:07:54,566
 friendship right now."
 
-153
+192
 00:07:54,987 --> 00:07:57,131
 And then, when we were moving
 into Hacktoberfest, I was
 
-154
+193
 00:07:57,131 --> 00:07:59,275
 like, "Hmm."
 
-155
+194
 00:08:01,286 --> 00:08:04,700
 I don't know who suggested it.
 Somehow, Kirk ended up on the
 
-157
+195
 00:08:04,700 --> 00:08:10,766
 Hacktoberfest team. And it was
 me, Dan, Sarah, Bryan, and Kirk.
 
-158
+196
 00:08:11,276 --> 00:08:15,000
 And I feel like me, Sarah, Dan,
 and Bryan were like,
 
-159
+197
 00:08:15,000 --> 00:08:16,500
 "[Talks fast] Talk, talk, talk,
 talk, talk."
 
-160
+198
 00:08:16,500 --> 00:08:20,187
 And Kirk was like, "Why don't we
 think about this for a second?"
 
-161
+199
 00:08:21,987 --> 00:08:26,000
-[All laugh] Like, "Yes, we
-shall -- probably should."
+[All laugh] Like, "Yes, we shall
+-- probably should."
 
-162
+200
 00:08:26,000 --> 00:08:27,000
 Dan: Notorious [??].
 
-163
+201
 00:08:27,500 --> 00:08:32,500
 Bekah: So, Kirk was always doing
 a great job of roping us all
 
-162
+202
 00:08:32,500 --> 00:08:35,300
 back to having productive
 conversations and making
 
-163
+203
 00:08:35,300 --> 00:08:39,000
 progress on all the things that
 we were really excited about
 
-165
+204
 00:08:39,000 --> 00:08:42,500
 doing, and making sure that they
 happen. And -- like, for me, I
 
-167
+205
 00:08:42,500 --> 00:08:46,486
 like -- had not really either am
 heard about documentation,
 
-169
+206
 00:08:46,486 --> 00:08:49,697
 like, talk about documentation
 [laughs]. Put like, "What is
 
-170
+207
 00:08:49,697 --> 00:08:52,456
 that thing?" And then, like,
 Kirk was like, breaking it down.
 
-171
+208
 00:08:52,456 --> 00:08:54,826
 This is why documentation is
 important. And then, you know,
 
-172
+209
 00:08:54,826 --> 00:08:58,037
 Kirk has a teaching background
 too. And so it was like, "Okay,
 
-173
+210
 00:08:58,037 --> 00:09:00,256
 this is starting to click a
 little bit more for me." And to,
 
-174
+211
 00:09:00,256 --> 00:09:04,366
 like, show how you can help more
 people through the documentation
 
-175
+212
 00:09:04,636 --> 00:09:08,836
 became something that was like a
 change in my life, you
 
-176
+213
 00:09:08,836 --> 00:09:11,700
 know? I will make no big deal,
 but [laughs] --
 
-177
+214
 00:09:11,700 --> 00:09:12,300
 Dan: No biggie.
 
-178
+215
 00:09:13,000 --> 00:09:16,246
 Bekah: [Laughs] That's all. So,
 all right. I'm
 
-178
+216
 00:09:16,246 --> 00:09:19,067
 gonna check out the chat now.
 That's my- my Kirk origin story,
 
-179
+217
 00:09:19,067 --> 00:09:22,336
 and this is how he's become to
 be my best friend ever since.
 
-180
+218
 00:09:22,336 --> 00:09:27,047
 Dan: Yeah. So we just got a
 comment from David saying,
 
-181
+219
 00:09:27,057 --> 00:09:28,876
 "So cool to see you in the same
 place -- physical place." Yeah.
 
-182
+220
 00:09:28,907 --> 00:09:31,216
 This is the first time that we
 have, like, actually met in real
 
-183
+221
 00:09:31,216 --> 00:09:34,226
 life. And we started working
 together ... when did we start
 
-184
+222
 00:09:34,226 --> 00:09:34,700
 working together?
 
-184
+223
 00:09:34,700 --> 00:09:37,496
 Bekah: July -- this will be --
 so, it would've been three years
 
-186
+224
 00:09:37,496 --> 00:09:37,700
 in July.
 
-187
+225
 00:09:37,700 --> 00:09:39,500
 Dan: Yeah. Before -- I mean,
 bef- before Virtual Coffee.
 
-188
+226
 00:09:39,500 --> 00:09:40,000
 Like, we were working-
 
-189
+227
 00:09:40,000 --> 00:09:40,300
 Bekah: Yeah.
 
-187
+228
 00:09:40,437 --> 00:09:43,700
 Dan: -together before Virtual
 Coffee started. And -- I mean --
 
-188
+229
 00:09:42,356 --> 00:09:44,700
 Bekah: Dan fired me. And that's
 how Virtual Coffee started
 
-189
+230
 00:09:44,700 --> 00:09:44,746
 [laughs].
 
-189
+231
 00:09:44,746 --> 00:09:47,037
 Dan: As soon as I said that, I
 knew you were gonna say that. I
 
-191
+232
 00:09:47,037 --> 00:09:49,500
 did not ... fire ... Bekah.
 
-192
+233
 00:09:49,500 --> 00:09:51,700
 Bekah: You did. My kids got sent
 home from school, and then I
 
-193
+234
 00:09:51,700 --> 00:09:54,716
 came home, and Dan was like,
 "Sorry, you're fired. Good luck
 
-194
+235
 00:09:54,716 --> 00:09:55,000
 [laughs]."
 
-194
+236
 00:09:57,300 --> 00:10:01,248
 Dan: Listen. I mean, sometimes
 you have to fire peep- people
 
-195
+237
 00:10:01,248 --> 00:10:03,760
 [laughs]. I didn't fire you,
 o-okay?
 
-196
+238
 00:10:03,761 --> 00:10:07,201
 You were a contractor, and so, I
 just stopped paying you, and you
 
-197
+239
 00:10:07,211 --> 00:10:08,000
 stopped doing work [laughs].
 
-198
+240
 00:10:09,000 --> 00:10:10,000
 Bekah: You're the worst
 [laughs].
 
-198
+241
 00:10:10,500 --> 00:10:13,700
 Dan: In my defense, I didn't
 have any money to pay you with
 
-199
+242
 00:10:13,700 --> 00:10:14,000
 [all laugh]. So --
 
-200
+243
 00:10:14,500 --> 00:10:15,500
 Bekah: It will get so --
 
-199
+244
 00:10:15,000 --> 00:10:16,756
 Dan: I didn't have any work for
 you to do.
 
-200
+245
 00:10:16,756 --> 00:10:18,491
 Bekah: All right. Fine. Fine.
 Fine.
 
-201
+246
 00:10:18,491 --> 00:10:21,700
 I'll be fair. It was pandemic.
 And there was no work.
 
-202
+247
 00:10:21,700 --> 00:10:26,500
 So, [laughs] he fired me on
 accident, apparently.
 
-203
+248
 00:10:26,500 --> 00:10:27,462
 Dan: Yeah. Nick knew you're
 gonna say that as well.
 
-204
+249
 00:10:27,462 --> 00:10:29,892
 You're becoming predictable.
 
-206
+250
 00:10:31,601 --> 00:10:33,500
 Bekah: [Laughs] But I feel like
 we've had a lot of new members
 
-207
+251
 00:10:33,500 --> 00:10:36,500
 that might not have known that
 you fired me many times
 
-208
+252
 00:10:36,500 --> 00:10:37,001
 ago [laughs].
 
-208
+253
 00:10:39,731 --> 00:10:45,432
 Dan: So, anyway, yes. So, I
 don't know about you,
 
-209
+254
 00:10:45,432 --> 00:10:50,500
 Bekah. I spent a lot of time,
 like, I'm like, "Okay. So, what
 
-210
+255
 00:10:50,500 --> 00:10:51,300
 do I wear when
 
-211
+256
 00:10:51,300 --> 00:10:54,011
 I meet a person for the first
 time, that I've, like, worked
 
-212
+257
 00:10:54,011 --> 00:10:56,682
 closely with for three years?"
 Obviously, Virtual Coffee
 
-213
+258
 00:10:56,682 --> 00:11:00,700
 stuff. I -- Bekah w-wore the
 t-shirt and the hoodie. I- I
 
-214
+259
 00:11:00,700 --> 00:11:01,741
 just wear those --
 
-214
+260
 00:11:01,741 --> 00:11:02,412
 Bekah: I understood the
 assignment.
 
-215
+261
 00:11:02,500 --> 00:11:04,721
 Dan: Yeah. Well, we didn't talk
 about it ahead of
 
-216
+262
 00:11:04,721 --> 00:11:07,300
 times. I almost, like, texted
 you. I almost, like, I almost
 
-217
+263
 00:11:07,300 --> 00:11:10,000
 asked you, and I should have.
 Because then we could have just
 
-219
+264
 00:11:10,000 --> 00:11:11,000
 been totally, you know?
 
-218
+265
 00:11:11,000 --> 00:11:13,152
 Bekah: Oh, wait. Arjun joined
 and wants to know who
 
-219
+266
 00:11:13,152 --> 00:11:14,532
 fired me. Dan fired me [laughs].
 
-220
+267
 00:11:14,532 --> 00:11:20,300
 Dan: No, I did not fire you [all
 laugh]. I hate this. I'm
 
-221
+268
 00:11:20,300 --> 00:11:21,491
 shutting this stream down.
 
-222
+269
 00:11:21,491 --> 00:11:24,131
 Bekah: No, wait. Yeah,
 [inaudible] [laughs].
 
-222
+270
 00:11:24,131 --> 00:11:27,731
 So, okay. So maybe let's go back
 a little bit so I can
 
-223
+271
 00:11:27,731 --> 00:11:31,182
 tell the full story and give Dan
 the credit that he is owned.
 
-224
+272
 00:11:31,211 --> 00:11:34,422
 I'm a career changer. I spent 10
 years teaching college English,
 
-225
+273
 00:11:34,782 --> 00:11:38,922
 and I went to bootcamp. And when
 I graduated, I put out a tweet
 
-226
+274
 00:11:38,922 --> 00:11:43,000
 saying that I was looking for a
 job. And Dan responded, and
 
-227
+275
 00:11:43,000 --> 00:11:43,500
 hired me.
 
-228
-00:11:43,500 --. 00:11:46,000
+276
+00:11:43,500 --> 00:11:46,000
 Dan: [Inaudible]. Not really.
 
-229
+277
 00:11:46,000 --> 00:11:46,300
 Bekah: Yeah.
 
-227
+278
 00:11:46,500 --> 00:11:50,300
 Dan: Not really, but ...
 seriously [laughs]. No, just
 
-228
+279
 00:11:50,300 --> 00:11:50,500
 kidding [all laugh].
 
-228
+280
 00:11:53,682 --> 00:11:56,321
 Bekah: So, I did not -- I didn't
 take any coding tests or
 
-229
+281
 00:11:56,321 --> 00:11:58,960
 have to
 
-230
+282
 00:11:58,961 --> 00:12:03,201
 do any s-strange problems that
 make no difference in the world.
 
-231
+283
 00:12:03,591 --> 00:12:08,542
-And so, we worked together
-until the pandemic hit and then
+And so, we worked together until
+the pandemic hit and then
 
-232
+284
 00:12:09,231 --> 00:12:10,300
 everything shut down. So-
 
-233
+285
 00:12:10,300 --> 00:12:10,500
 Dan: Yeah.
 
-234
+286
 00:12:11,000 --> 00:12:11,500
 Bekah: -so, Dan --
 
-235
+287
 00:12:11,700 --> 00:12:12,300
 Dan: And I --
 
-236
+288
 00:12:12,300 --> 00:12:13,000
 Bekah: I joked [laughs] --
 
-233
+289
 00:12:13,251 --> 00:12:16,131
 Dan: As soon as I had work
 coming back in, you had
 
-234
+290
 00:12:16,131 --> 00:12:17,500
 work coming back in too.
 
-235
+291
 00:12:17,500 --> 00:12:17,700
 Bekah: Yeah.
 
-236
+292
 00:12:17,700 --> 00:12:19,500
 Dan: Cuz you never ... say --
 
-237
+293
 00:12:19,500 --> 00:12:20,700
 Bekah: He- he rehired me
 [laughs].
 
-238
+294
 00:12:20,700 --> 00:12:26,211
 Dan: Oh, okay, thank you. Thank
 you [all laugh]. Well, yeah. It
 
-236
+295
 00:12:26,211 --> 00:12:27,700
 was ru- it was a rough summer.
 It was a weird summer.
 
-237
+296
 00:12:28,000 --> 00:12:30,000
 Bekah: That was really rough.
 And that's how Virtual Coffee
 
-238
+297
 00:12:30,000 --> 00:12:32,991
 started too. Because I was
 getting assigned with
 
-240
+298
 00:12:32,991 --> 00:12:37,491
 interviews with kids at home and
 trying to figure out, like, what
 
-241
+299
 00:12:37,491 --> 00:12:42,700
 life was like [chuckles]. And
 then, I put out a tweet, "Does
 
-242
+300
 00:12:42,700 --> 00:12:43,371
 anybody wanna
 
-243
+301
 00:12:43,371 --> 00:12:46,000
 meet up for Virtual Coffee?" And
 we just kept going with it. And-
 
-244
+302
 00:12:46,341 --> 00:12:50,000
 and somewhere along the line, I
 pulled Dan in too [chuckles].
 
-245
+303
 00:12:50,000 --> 00:12:50,300
 Dan: Yeah.
 
-245
+304
 00:12:51,000 --> 00:12:53,000
-Bekah: Cuz he owed me for
-firing me [laughs].
+Bekah: Cuz he owed me for firing
+me [laughs].
 
-246
+305
 00:12:53,000 --> 00:12:59,397
 Dan: Oh, gosh [chuckles].
 Alright. Alright.
 
-247
+306
 00:12:59,397 --> 00:13:05,096
 So, here's the one thing. I'm-
 I'm so used to, like, talking to
 
-248
+307
 00:13:05,096 --> 00:13:07,197
 you on Zoom. We're sitting right
 next to each other, but we have
 
-249
+308
 00:13:07,197 --> 00:13:11,547
 the, like, Zoom monitor on the
 screen. And so, I have been like
 
-250
+309
 00:13:11,547 --> 00:13:13,300
 looking at -- I keep looking at
 you on the screen instead of-
 
-251
+310
 00:13:13,300 --> 00:13:14,700
 instead of, like, you next to
 me.
 
-252
+311
 00:13:14,700 --> 00:13:15,000
 Bekah: Yeah.
 
-252
+312
 00:13:15,000 --> 00:13:15,626
 Dan: I don't even understand.
 
-253
+313
 00:13:15,626 --> 00:13:17,000
 Bekah: Yeah. I'm not really
 sure-
 
-254
+314
 00:13:16,500 --> 00:13:17,700
 Dan: It's more the -- I don't
 understand it.
 
-255
+315
 00:13:17,000 --> 00:13:18,700
 Bekah: -how's the deal. Am I
 suppose to look at you when I
 
-256
+316
 00:13:18,700 --> 00:13:19,346
 talk to you?
 
-254
+317
 00:13:19,346 --> 00:13:20,576
 Dan: No. Right. Exactly. Yeah,
 right. Do I look to camera? Do
 
-255
+318
 00:13:20,576 --> 00:13:21,806
 you -- yeah. No,
 
-256
+319
 00:13:21,807 --> 00:13:25,677
 it's weird. Good weird, but
 it's- it's weird, you know?
 
-257
+320
 00:13:25,677 --> 00:13:26,000
 Bekah: Mm-hmm.
 
-258
+321
 00:13:26,000 --> 00:13:26,700
 Dan: [Inaudible]. Yeah.
 
-257
+322
 00:13:27,567 --> 00:13:31,091
 Bekah: Yeah. Okay. Let's see.
 Let me look at this chat.
 
-258
+323
 00:13:34,000 --> 00:13:36,700
 [Laughs] Yes, Nick. Exactly.
 "Dan responded, 'I'm looking for
 
-259
+324
 00:13:36,700 --> 00:13:37,500
 someone to fire eventually.'"
 
-261
+325
 00:13:37,797 --> 00:13:38,700
 Dan: It was really just the
 power of truth.
 
-262
+326
 00:13:38,300 --> 00:13:39,700
 Bekah: I was like, "Yeah. I am
 totally-
 
-263
+327
 00:13:39,000 --> 00:13:41,700
 Dan: Man. That's- that's -- all
 of work -- all of our work are-
 
-264
+328
 00:13:40,000 --> 00:13:42,000
 Bekah: -here for being fired
 eventually [laughs]."
 
-265
+329
 00:13:41,700 --> 00:13:42,500
 Dan: -out of life. Yeah.
 
-266
+330
 00:13:43,500 --> 00:13:46,300
 Just a power to fire somebody,
 and then [inaudible].
 
-262
+331
 00:13:45,626 --> 00:13:47,051
 Bekah: No, I had no coding
 tests. We had a conversation. I
 
-264
+332
 00:13:47,051 --> 00:13:50,486
 don't know if Dan remembers it,
 but I remember --
 
-265
+333
 00:13:50,486 --> 00:13:55,500
 Dan: I did. Yeah. I mean, I
 didn't know what I was doing
 
-266
+334
 00:13:55,500 --> 00:13:58,000
 either. It was -- I mean, this
 is the first time I ever -- and
 
-266
-00:13:58,000 --> 00:13:59,84
+335
+00:13:58,000 --> 00:13:59,846
 to be clear, like, you weren't
 
-268
+336
 00:13:59,846 --> 00:14:03,506
 an employee, so, you know? I --
 my whole thing was contractor,
 
-269
+337
 00:14:03,506 --> 00:14:06,386
 you know? Cuz I'm a contractor
 too. But, yeah. I'd never done
 
-271
+338
 00:14:06,386 --> 00:14:08,576
 that before. And like, I really
 jumped into, like, very ADHD
 
-272
+339
 00:14:08,576 --> 00:14:15,500
 style, like, no real plan, no
 real, you know, guidelines for
 
-273
+340
 00:14:15,500 --> 00:14:18,500
 myself or for anybody else or
 anything like that. And it
 
-274
+341
 00:14:18,500 --> 00:14:20,125
 worked out very well.
 
-276
+342
 00:14:20,125 --> 00:14:22,000
 Bekah: It did! It worked out
 really well.
 
-276
+343
 00:14:22,000 --> 00:14:27,267
 Dan: But ... yeah, I dunno. It
 was- it was- it was fun.
 
-277
+344
 00:14:28,317 --> 00:14:31,772
 I'm -- I've been missing -- you
 know, Bekah, you gotta ... I
 
-278
+345
 00:14:31,772 --> 00:14:32,000
 dunno.
 
-278
+346
 00:14:32,000 --> 00:14:32,700
 Bekah: I fired Dan.
 
-279
+347
 00:14:32,700 --> 00:14:33,300
 Dan: I was gonna say-
 
-280
+348
 00:14:33,000 --> 00:14:34,000
 Bekah: And I got a new job
 [laughs].
 
-281
+349
 00:14:33,500 --> 00:14:34,300
 Dan: -you got a job. Yeah.
 
-279
+350
 00:14:35,522 --> 00:14:40,000
 Yeah. So, you know, with, like,
 insurance-
 
-280
+351
 00:14:40,000 --> 00:14:40,300
 Bekah: Yeah.
 
-280
+352
 00:14:40,500 --> 00:14:42,500
 Dan: -I've heard is a good thing
 to have.
 
-281
+353
 00:14:42,500 --> 00:14:44,322
 Bekah: Insurance is nice. It's
 useful.
 
-282
+354
 00:14:44,322 --> 00:14:44,700
 Dan: So, you know --
 
-282
+355
 00:14:46,111 --> 00:14:50,000
 Bekah: Didn't have that for a
 while [all chuckle]. So, yeah.
 
-283
+356
 00:14:50,000 --> 00:14:51,692
 So, I've been working a new
 
-283
+357
 00:14:51,692 --> 00:14:55,892
-full-time job, and Dan has
-been --
+full-time job, and Dan has been
+--
 
-284
+358
 00:14:57,361 --> 00:15:01,412
 Dan: Yes. Ayu, thank you. If I
 didn't fire you, there'll be no
 
-285
+359
 00:15:01,412 --> 00:15:04,500
 Virtual Coffee. I didn't fire
 you. God! I got tricked!
 
-286
+360
 00:15:03,500 --> 00:15:05,500
 Bekah: [Laughs] He did it.
 Somebody-
 
-287
+361
 00:15:05,500 --> 00:15:06,000
 Dan: Ooh, no.
 
-288
+362
 00:15:06,000 --> 00:15:06,700
 Bekah: -please grab that.
 
-289
+363
 00:15:06,700 --> 00:15:08,000
 Dan: No. We're shutting this
 whole thing now.
 
-290
+364
 00:15:07,000 --> 00:15:08,000
 Bekah: Grab that from this
 video-
 
-291
+365
 00:15:09,000 --> 00:15:10,000
 Dan: We're shutting it down.
 
-292
+366
 00:15:10,500 --> 00:15:13,000
 Bekah: -so I can play it over
 and over [laughs].
 
-287
+367
 00:15:14,412 --> 00:15:18,192
 Dan: I blamed Melts, honestly,
 for that- for that one. We went
 
-288
+368
 00:15:18,192 --> 00:15:21,700
 to Melt in here, in Lakewood.
 And there, it's -- I -- we
 
-289
+369
 00:15:21,700 --> 00:15:22,870
 walked past -- the first
 
-290
+370
 00:15:22,871 --> 00:15:25,841
 place I wanted to go, found out
 close for lunch on the weekdays,
 
-291
+371
 00:15:26,022 --> 00:15:29,142
-which I didn't know. But as
-we were walking past Melt, I was
+which I didn't know. But as we
+were walking past Melt, I was
 
-292
+372
 00:15:29,142 --> 00:15:31,751
 like, this place makes you wanna
 go take a nap after, like,
 
-293
+373
 00:15:31,782 --> 00:15:32,000
 after.
 
-294
+374
 00:15:32,700 --> 00:15:33,000
 Bekah: Mm-hmm.
 
-295
+375
 00:15:33,000 --> 00:15:34,000
 Dan: And it's- it's true.
 
-296
+376
 00:15:34,000 --> 00:15:35,000
 Bekah: Can confirm.
 
-294
+377
 00:15:35,000 --> 00:15:36,642
 Dan: Yeah. I mean, the two beers
 probably- probably not bad
 
-295
+378
 00:15:37,991 --> 00:15:42,500
 either. But, I blame -- yeah. I
 blame- I blame that on that- on
 
-297
+379
 00:15:42,500 --> 00:15:46,000
 that mental lapse. But I want to
 stand firm that I did not fire
 
-298
+380
 00:15:46,000 --> 00:15:46,451
 anybody.
 
-299
+381
 00:15:47,201 --> 00:15:49,991
 Bekah: I mean, what is your
 definition of fire, okay? He was
 
-300
+382
 00:15:49,991 --> 00:15:54,131
 like, "I'm no longer going to
 employ you or give you work or
 
-301
+383
 00:15:54,131 --> 00:15:58,000
 money." So, anybody out there,
 please let me know [laughs].
 
-302
+384
 00:16:01,000 --> 00:16:02,000
 Dan: Whatever.
 
-302
+385
 00:16:03,500 --> 00:16:06,500
 Bekah: So now, he's roped into
 Virtual Coffee-
 
-303
+386
 00:16:06,500 --> 00:16:07,000
 Dan: Oh, god.
 
-304
+387
 00:16:07,000 --> 00:16:07,961
 Bekah: -forever [laughs].
 
-303
+388
 00:16:09,000 --> 00:16:16,300
 Dan: Oh, man. Anyway, let's go
 back to Ayu was saying that I
 
-304
+389
 00:16:16,300 --> 00:16:18,861
 was right. And --
 
-305
+390
 00:16:18,861 --> 00:16:20,500
 Bekah: I don't think that's what
 Ayu said, okay [chuckles]?
 
-304
+391
 00:16:20,500 --> 00:16:22,300
 Dan: Yeah, yeah. Well, that-
 that everything that I did was
 
-305
+392
 00:16:22,300 --> 00:16:22,700
 good.
 
-306
+393
 00:16:22,700 --> 00:16:25,000
 Bekah: She 100% did not say
 that.
 
-305
+394
 00:16:24,500 --> 00:16:26,451
 Dan: Yeah, no. I'm pretty sure
 that's what she said. And --
 
-306
+395
 00:16:26,451 --> 00:16:26,700
 Bekah: She did not!
 
-307
+396
 00:16:27,500 --> 00:16:30,000
-Dan: No, I tried to scroll.
-We can't- we can't scroll back.
+Dan: No, I tried to scroll. We
+can't- we can't scroll back.
 
-308
+397
 00:16:30,000 --> 00:16:31,000
-That's -- we can't [chuckles]
---
+That's -- we can't [chuckles] --
 
-307
+398
 00:16:28,000 --> 00:16:31,341
 Bekah: She's like, "Dan, it
 sucks that you fired Bekah and
 
-308
+399
 00:16:31,341 --> 00:16:33,500
 that was pretty awful. But at
 least we got Virtual Coffee out
 
-309
+400
 00:16:33,500 --> 00:16:34,000
 of it [laughs]."
 
-310
+401
 00:16:35,000 --> 00:16:37,500
 Dan: We can't scroll back and
 see what she says. [Inaudible].
 
-310
+402
 00:16:35,500 --> 00:16:40,000
 Bekah: Nick tells, "Dan- Dan,
 you can fire me any day [all
 
-311
+403
 00:16:40,000 --> 00:16:42,456
 laugh]." I don't even know what
 that means [laughs].
 
-312
+404
 00:16:45,000 --> 00:16:45,700
 Dan: Ooh, Nick.
 
-311
+405
 00:16:47,000 --> 00:16:49,300
 Bekah: Sometimes, I, like, very
 frequently will spit out water
 
-312
+406
 00:16:49,300 --> 00:16:53,000
 when I drink it. So I need to
 try very hard to not drink and
 
-313
+407
 00:16:53,000 --> 00:16:54,000
 laugh at the same time.
 
-314
+408
 00:16:54,000 --> 00:16:59,966
 Dan: Hmm, wait. Who's ... yeah.
 Somebody's episode. That was a
 
-315
+409
 00:16:59,966 --> 00:17:00,500
 really good one of that.
 
-316
+410
 00:17:00,500 --> 00:17:02,366
 Bekah: Oh, oh, it's Helen!
 
-316
+411
 00:17:02,366 --> 00:17:02,700
 Dan: Oh yeah, Helen.
 
-317
+412
 00:17:02,700 --> 00:17:03,000
 Bekah: Yeah.
 
-318
+413
 00:17:03,000 --> 00:17:04,766
 Dan: Yeah. Yeah, I watched you
 do it. I watched you swallow or,
 
-317
+414
 00:17:04,767 --> 00:17:07,287
 like, you know, start to drink
 water. And then Helen said
 
-319
+415
 00:17:07,287 --> 00:17:09,500
 something hilarious, and, yeah.
 
-320
+416
 00:17:09,500 --> 00:17:10,500
 Bekah: I didn't mute myself.
 
-321
+417
 00:17:10,500 --> 00:17:11,300
 Dan: I was like, "Oh, please."
 
-322
+418
 00:17:10,700 --> 00:17:13,000
 Bekah: I was like choking for
 five minutes [laughs].
 
-321
+419
 00:17:14,000 --> 00:17:18,000
 Dan: We -- yeah, Bekah and I
 both have a- a problem with --
 
-321
+420
 00:17:18,000 --> 00:17:20,517
 sometimes we, you know, you -- I
 don't know if you could get this
 
-322
+421
 00:17:20,517 --> 00:17:23,876
 in Zoom, where you ... you --
 you're not, like, making eye
 
-323
+422
 00:17:23,876 --> 00:17:26,727
 contact with a real person, you
 know? But- but like, you almost
 
-324
-00:17:26,727 --> 00:17:26,500
+423
+00:17:26,727 --> 00:17:26,728
 can, like-
 
-325
-00:17:26,500 -->00:17:26,700
+424
+00:17:26,500 --> 00:17:26,700
 Bekah: Yeah.
 
-326
+425
 00:17:26,600 --> 00:17:28,500
 Dan: -in Zoom, sometimes, you
 know? Where, like, you know,
 
-325
+426
 00:17:28,500 --> 00:17:29,307
 you're looking at
 
-326
+427
 00:17:29,307 --> 00:17:31,047
 that person, you know they're
 looking at you, you know?
 
-328
+428
 00:17:31,616 --> 00:17:34,000
 And, yeah. We've had some- we've
 had some meltdowns in the- in
 
-329
+429
 00:17:34,000 --> 00:17:36,000
 the past [all laugh].
 
-330
+430
 00:17:36,300 --> 00:17:38,500
 We try to keep it, you know,
 it's all on the podcast. But
 
-331
+431
 00:17:38,500 --> 00:17:41,666
 there's been some- there's been
 some- there's been some moments.
 
-332
+432
 00:17:42,477 --> 00:17:44,700
 Bekah: Yeah. Yeah. There are
 many moments on the podcast.
 
-334
+433
 00:17:44,700 --> 00:17:47,700
 We've progressed so much. When
 we first started the podcast, I
 
-336
+434
 00:17:47,700 --> 00:17:50,541
 would laugh uncontrollably for
 the first five minutes and I
 
-338
+435
 00:17:50,541 --> 00:17:53,700
 could never do the introduction.
 I -- maybe there's -- I don't
 
-339
+436
 00:17:53,700 --> 00:17:55,000
 know if there's any [inaudible]
 [laughs].
 
-340
+437
 00:17:55,797 --> 00:17:56,700
 Dan: No, we have it all on tape,
 for sure. We sure have it all
 
-341
+438
 00:17:56,700 --> 00:17:59,300
 recorded. I don't know if --
 yeah. I don't know how much
 
-341
+439
 00:17:59,300 --> 00:18:04,000
 video we have of it, but, like,
 we have a lot of views of- of
 
-343
+440
 00:18:04,000 --> 00:18:05,500
 the, like, trying to do the
 intros and stuff.
 
-344
+441
 00:18:05,500 --> 00:18:06,700
 Bekah: [Laughs] I just couldn't.
 I just would -- just --
 
-345
+442
 00:18:06,700 --> 00:18:09,000
 Dan: It's so funny. Cuz you're
 so good at it. Like,
 
-346
+443
 00:18:09,000 --> 00:18:12,500
 you're so good at, like, this
 stuff most of the time. And like
 
-347
+444
 00:18:12,500 --> 00:18:14,700
 -- it's the recorded nature of
 it. It's like the reading the
 
-348
+445
 00:18:14,700 --> 00:18:15,057
 script part-
 
-348
+446
 00:18:15,057 --> 00:18:15,500
 Bekah: It was like-
 
-349
+447
 00:18:15,300 --> 00:18:16,000
 Dan: I felt that- I felt that --
 
-350
+448
 00:18:15,500 --> 00:18:16,700
 Bekah: -I was so nervous.
 
-351
+449
 00:18:16,700 --> 00:18:18,000
 Dan: Yeah. I feel like that was
 [inaudible].
 
-352
+450
 00:18:17,000 --> 00:18:18,700
 Bekah: Like, it [laughs]- it
 was, like,
 
-349
+451
 00:18:18,866 --> 00:18:22,076
 nervousness decided to turn
 itself into laughters. And like,
 
-350
+452
 00:18:22,076 --> 00:18:25,676
 I could not stop. Which I guess
 is, like, better than crying or
 
-351
+453
 00:18:25,676 --> 00:18:29,067
 sweating, which I have also gone
 through those phases as well.
 
-352
+454
 00:18:29,217 --> 00:18:32,547
 Dan: Yeah, sweat is definitely
 one of my main skills.
 
-353
+455
 00:18:34,317 --> 00:18:36,000
 Bekah: Just checking out the
 chat.
 
-354
+456
 00:18:36,000 --> 00:18:36,300
 Dan: Yeah.
 
-355
+457
 00:18:37,000 --> 00:18:38,231
 Bekah: Promote it to customer
 [all laugh].
 
-354
+458
 00:18:41,741 --> 00:18:47,700
 Dan: Yes. Congratulations,
 [inaudible]. Some -- I don't
 
-355
+459
 00:18:47,700 --> 00:18:48,392
 know. Pressure valves?
 
-355
+460
 00:18:48,392 --> 00:18:52,300
 Bekah: [Laughs] Yeah, Suze. He
 probably would fire me for all
 
-357
+461
 00:18:52,300 --> 00:18:58,000
 of this. It's okay. [Laughs] Oh,
 am I sure I'm an introvert? I
 
-358
+462
 00:18:58,000 --> 00:18:58,922
 dunno. I feel
 
-358
+463
 00:18:58,922 --> 00:19:03,541
 like maybe I'm an amvivert --
 ambivert? I am, especially, like
 
-359
+464
 00:19:03,541 --> 00:19:07,862
 intensely nervous, and shy, and
 exhausted when I'm around people
 
-360
+465
 00:19:07,862 --> 00:19:10,700
 that I don't know. But like,
 when I'm around people that I
 
-361
+466
 00:19:10,700 --> 00:19:11,612
 know or
 
-361
+467
 00:19:11,612 --> 00:19:15,700
 people that I'm friends with,
 then I can often, like, find
 
-363
+468
 00:19:15,700 --> 00:19:18,241
 that energy I think that
 extroverts have.
 
-364
+469
 00:19:18,241 --> 00:19:24,692
 Dan: For- for me, it's -- for
 me, it's sort of knowing exactly
 
-365
+470
 00:19:24,692 --> 00:19:26,700
 what, like, I was supposed to
 do-
 
-366
+471
 00:19:26,700 --> 00:19:27,000
 Bekah: Yeah.
 
-367
+472
 00:19:27,000 --> 00:19:29,500
 Dan: -in a situation. That's
 what I'm comfortable,
 
-366
+473
 00:19:29,500 --> 00:19:32,922
 right? And so, like, the -- this
 is just you and me
 
-367
+474
 00:19:32,922 --> 00:19:35,261
 chatting, you know? And like,
 we've practiced this, obviously.
 
-368
+475
 00:19:35,261 --> 00:19:36,192
 So it's like, you know, talking,
 like --
 
-369
+476
 00:19:36,192 --> 00:19:38,500
 Bekah: We didn't practice this.
 But like, we've been [laughs] --
 
-370
+477
 00:19:38,000 --> 00:19:40,916
 Dan: Well, I -- no. Can't you
 tell? We did, like- we did, like
 
-371
+478
 00:19:40,916 --> 00:19:43,061
 [laughs], this is -- yeah,
 
-372
+479
 00:19:43,092 --> 00:19:48,000
 very polished, you know, thing.
 No. But what I mean is like, I
 
-374
+480
 00:19:48,000 --> 00:19:52,210
 know what socially is expected
 of me in this situation.
 
-376
+481
 00:19:52,241 --> 00:19:56,471
 You know what I mean? And so, if
 I'm in coffee, like, one of our
 
-377
+482
 00:19:56,471 --> 00:20:00,402
 coffee chats, and in a room with
 a whole bunch of people I don't
 
-378
+483
 00:20:00,402 --> 00:20:02,832
 know, I'm not, like, I don't
 have a problem. Like, I don't- I
 
-379
+484
 00:20:02,832 --> 00:20:08,300
 don't get, like, awkward like
 that. But- but when I go to,
 
-380
+485
 00:20:08,300 --> 00:20:09,490
 like, go to a
 
-381
+486
 00:20:09,491 --> 00:20:12,162
 conference, right? And then,
 there's like a social hour or
 
-382
+487
 00:20:12,162 --> 00:20:15,162
 lunch or whatever, and I don't
 know people, and I don't know
 
-383
+488
 00:20:15,162 --> 00:20:18,192
 exactly what I'm supposed to do
 or, like, my role in, you know,
 
-384
+489
 00:20:18,192 --> 00:20:18,500
 that's when I get, like-
 
-385
+490
 00:20:18,500 --> 00:20:18,700
 Bekah: Yeah.
 
-386
+491
 00:20:18,700 --> 00:20:20,000
 Dan: -that's when I get, like,
 super-
 
-385
+492
 00:20:20,000 --> 00:20:20,200
 Bekah: Yep.
 
-386
+493
 00:20:20,200 --> 00:20:20,832
 Dan: -and I just go and
 
-385
+494
 00:20:20,832 --> 00:20:22,662
 sit down by myself, and put my
 headphones on or so- or -- I
 
-386
+495
 00:20:22,662 --> 00:20:24,820
 don't put my headphones on. But
 like -- cuz I'm fine if somebody
 
-388
+496
 00:20:24,821 --> 00:20:25,856
 comes [chuckles] and talks to
 me, like, that's cool.
 
-389
+497
 00:20:25,856 --> 00:20:26,000
 Bekah: Yeah.
 
-390
+498
 00:20:26,000 --> 00:20:26,891
 Dan: Cuz that's like,
 
-390
+499
 00:20:27,672 --> 00:20:29,000
 "Hey, this is what you're
 supposed to do now," you know?
 
-392
+500
 00:20:29,000 --> 00:20:33,000
 But like, walking up to somebody
 and trying to, like ... that's-
 
-394
+501
 00:20:33,000 --> 00:20:35,300
 that's what I -- like, I really
 struggled with that. That-
 
-395
+502
 00:20:35,300 --> 00:20:35,500
 Bekah: Yeah.
 
-396
+503
 00:20:35,500 --> 00:20:36,700
 Dan: -that's the kind of stuff
 that I struggled with,
 
-395
+504
 00:20:36,700 --> 00:20:42,500
 you know? Is those- those, like,
 situations ... where it's an
 
-396
+505
 00:20:42,500 --> 00:20:45,112
 unfamiliar territory or like ...
 you know? I dunno.
 
-398
+506
 00:20:45,612 --> 00:20:46,000
 Bekah: Yeah.
 
-399
+507
 00:20:46,000 --> 00:20:47,000
 Dan: Something like that. So --
 
-400
+508
 00:20:47,000 --> 00:20:48,311
 Bekah: My dad was just telling
 my-
 
-401
+509
 00:20:48,311 --> 00:20:48,551
 Dan: Super [inaudible].
 
-399
+510
 00:20:48,551 --> 00:20:51,500
 Bekah: -oldest — my 12-year-old.
 He was talking about how great
 
-400
+511
 00:20:51,500 --> 00:20:54,500
 it is to talk to, like, random
 people, and to go up and talking
 
-401
+512
 00:20:54,500 --> 00:20:56,142
 to them, like, "Dad, that is-
 that is
 
-402
+513
 00:20:56,142 --> 00:20:58,511
 a terrible thing." My dad loves
 it. Like, he will go up to any
 
-403
+514
 00:20:58,511 --> 00:21:01,541
 person, and he will probably try
 and say what their na- he'll
 
-404
+515
 00:21:01,541 --> 00:21:04,031
 ask them their name and hope
 continually try and repeat that
 
-405
+516
 00:21:04,061 --> 00:21:06,551
 throughout the conversation, but
 then forget their name and use a
 
-406
+517
 00:21:06,551 --> 00:21:08,000
 different name that's wrong
 [laughs].
 
-407
+518
 00:21:09,500 --> 00:21:10,000
 Dan: [Laughs] That's awesome.
 
-408
+519
 00:21:10,000 --> 00:21:11,000
 Bekah: He tries very hard to be
 personal.
 
-407
+520
 00:21:11,700 --> 00:21:12,000
 Dan: Yeah.
 
-407
+521
 00:21:12,500 --> 00:21:15,700
 Bekah: But there's, like, my
 worst nightmare talking to a-
 
-408
+522
 00:21:15,700 --> 00:21:16,000
 Dan: Yeah.
 
-408
+523
 00:21:16,362 --> 00:21:18,000
 Bekah: -stranger that I don't
 know about things.
 
-409
+524
 00:21:17,500 --> 00:21:19,000
 Dan: Yeah. Yeah.
 
-410
+525
 00:21:19,000 --> 00:21:19,500
 Bekah: I can't.
 
-411
+526
 00:21:20,000 --> 00:21:22,500
 Dan: Yeah. No, my father-in-law
 is huge -- he big on that. And
 
-410
+527
 00:21:22,500 --> 00:21:22,961
 he was a bartender
 
-411
+528
 00:21:22,961 --> 00:21:25,571
 and stuff. And like, he just
 doesn't naturally -- like, he
 
-412
+529
 00:21:25,571 --> 00:21:29,382
 does it almost like impulsively,
 you know? But like- like, in
 
-413
+530
 00:21:29,382 --> 00:21:32,172
 an elevator or something, he'll
 just like chat up, and they
 
-414
+531
 00:21:32,172 --> 00:21:34,000
 probably don't wanna talk to
 him. Well, I mean, like -- not
 
-415
+532
 00:21:34,000 --> 00:21:35,741
 like -- he's not being creepy or
 anything.
 
-416
+533
 00:21:35,741 --> 00:21:36,000
 Bekah: Right.
 
-417
+534
 00:21:35,800 --> 00:21:36,942
 Dan: And he's not, like, hitting
 on anybody or anything like
 
-417
+535
 00:21:36,942 --> 00:21:39,281
 that. But he would just like ...
 talking to them.
 
-418
+536
 00:21:39,281 --> 00:21:40,000
 Bekah: He would be friends with
 my- my dad [laughs].
 
-419
-00:21:40,000 --. 00:21:40,700
+537
+00:21:40,000 --> 00:21:40,700
 Dan: [Laughs] Right, right.
 Yeah.
 
-420
+538
 00:21:40,700 --> 00:21:42,791
 Bekah: They would talk to each
 other in the elevator.
 
-419
+539
 00:21:42,791 --> 00:21:43,700
 Dan: [Inaudible]. He's, like,
 great guy. You know what I mean?
 
-420
+540
 00:21:43,700 --> 00:21:48,000
 And like, but that's just how he
 is, you know? And ... yeah.
 
-420
+541
 00:21:49,300 --> 00:21:53,000
 Somebody said something about --
 Joe said some- "What do I do
 
-422
+542
 00:21:53,000 --> 00:21:55,300
 with my hands?" That's a big
 thing with me too. And honestly,
 
-424
+543
 00:21:55,300 --> 00:21:57,701
 that's like -- what I -- one of
 the things I like
 
-425
+544
 00:21:57,701 --> 00:22:01,000
 about the -- this- this phase in
 our, like, collective lives of
 
-426
+545
 00:22:01,000 --> 00:22:03,700
 the Zoom stuff is that most
 times -- so right now, my
 
-427
+546
 00:22:03,700 --> 00:22:05,651
 camera's like scooted back a
 little bit so that we can both
 
-428
+547
 00:22:05,651 --> 00:22:17,500
 fit in. Most time, you can't see
 
-429
-00:22:17,500 --> 00:22:10,700
+548
+00:22:17,500 --> 00:22:17,501
 my hands. And I've, honestly,
 like, during this thing, I had
 
-430
+549
 00:22:10,700 --> 00:22:14,300
 been, like, seeing my hands in
 the video, and been like, "Oh,
 
-431
+550
 00:22:14,300 --> 00:22:16,811
 god. Get these out of here," you
 know? Cuz I'm just like- like, I
 
-432
+551
 00:22:16,811 --> 00:22:17,936
 don't know. What do I do with my
 hands? Big problem. Yeah. What
 
-434
+552
 00:22:19,061 --> 00:22:23,300
 do I do with my whole body?
 Like, standing in a group of
 
-435
+553
 00:22:24,300 --> 00:22:26,300
 people. How do I stand? You
 know? Like [chuckles],
 
-436
+554
 00:22:26,300 --> 00:22:27,000
 seriously, like, I -- I've --
 
-437
+555
 00:22:27,000 --> 00:22:27,300
 Bekah: Yeah.
 
-438
+556
 00:22:27,300 --> 00:22:28,700
 Dan: -I've struggled with that,
 you know?
 
-436
+557
 00:22:28,700 --> 00:22:31,076
 Like, I don't -- do I just put
 my hands in my pockets
 
-437
+558
 00:22:31,136 --> 00:22:31,977
 or, you know? I dunno.
 
-438
+559
 00:22:31,977 --> 00:22:34,000
 Bekah: That's why I like
 pockets.
 
-439
+560
 00:22:33,700 --> 00:22:34,000
 Dan: Yeah, yeah.
 
-439
+561
 00:22:34,000 --> 00:22:34,616
 Bekah: And they just don't make
 enough pockets for women.
 
-440
+562
 00:22:34,616 --> 00:22:35,000
 Dan: Yeah. Yeah.
 
-439
+563
 00:22:35,000 --> 00:22:36,000
 Bekah: It's like, even earlier-
 
-440
+564
 00:22:36,300 --> 00:22:37,000
 Dan: Pockets is -- are great.
 
-441
+565
 00:22:36,500 --> 00:22:37,500
 Bekah: -I -- we're -- Dan and I
 were like sitting
 
-440
+566
 00:22:37,500 --> 00:22:41,247
 at this conference table talking
 -- like, I move around a lot,
 
-441
+567
 00:22:41,247 --> 00:22:43,000
 and I've, like, recently, become
 more aware-
 
-442
+568
 00:22:43,000 --> 00:22:43,300
 Dan: Mm-hmm.
 
-443
+569
 00:22:43,500 --> 00:22:45,416
 Bekah: -of how much I move by
 
-442
+570
 00:22:45,416 --> 00:22:48,297
 seeing other people on camera.
 And then I'm like constant- I
 
-443
+571
 00:22:48,297 --> 00:22:50,247
 think someone once gave me like
 feedback, "Don't move your hands
 
-444
+572
 00:22:50,247 --> 00:22:53,000
 so much. It's distracting."
 Like, whatever. Like, I'm gonna
 
-445
+573
 00:22:53,000 --> 00:22:56,300
 move my hands as much as I want
 it. Like, because I can. I said,
 
-446
+574
 00:22:56,300 --> 00:22:59,700
 I -- we've got spinny -- Dan's
 got spinny chair. So I got to do
 
-447
+575
 00:22:59,700 --> 00:23:04,300
 a lot of spinning [chuckles].
 This is- this is what I do. I
 
-449
+576
 00:23:04,300 --> 00:23:05,700
 move all the time. But, like-
 
-450
+577
 00:23:05,700 --> 00:23:06,700
 Dan: Yeah. You do it a lot too.
 
-451
+578
 00:23:05,750 --> 00:23:07,907
 Bekah: -when I'm in front of the
 camera in my office,
 
-450
+579
 00:23:07,907 --> 00:23:12,300
 like, I very much try -- I- I
 have to try very hard to sit
 
-451
+580
 00:23:12,300 --> 00:23:13,000
 still [chuckles]-
 
-452
+581
 00:23:13,000 --> 00:23:13,300
 Dan: Yeah.
 
-453
+582
 00:23:13,500 --> 00:23:16,500
 Bekah: -and not move my hands
 everywhere because that is not
 
-452
+583
 00:23:16,500 --> 00:23:17,757
 my natural state of being.
 
-453
+584
 00:23:17,757 --> 00:23:19,500
 Dan: It's hard. [Bekah chuckles]
 It's hard.
 
-453
+585
 00:23:23,136 --> 00:23:26,497
 Waving your hair -- ha-hands in
 the air. Yes. Joe said --
 
-454
+586
 00:23:26,497 --> 00:23:28,500
 Bekah: We did the wave one time
 at Virtual Coffee-
 
-455
+587
 00:23:28,500 --> 00:23:29,000
 Dan: Ooh, right.
 
-456
+588
 00:23:28,550 --> 00:23:31,700
 Bekah: -in my breakout room. We,
 like, alf- we- we alphabetized
 
-455
+589
 00:23:31,700 --> 00:23:36,000
 everybody, and then everybody
 went. It was very exciting.
 
-457
+590
 00:23:39,997 --> 00:23:43,000
 Dan: Do we miss -- oh, no. Oh,
 Marie had to go.
 
-458
+591
 00:23:43,000 --> 00:23:44,300
 Bekah: Oh, Marie.
 
-459
+592
 00:23:44,300 --> 00:23:49,000
 Dan: We will see you, Marie.
 Yeah. I dunno.
 
-458
+593
 00:23:49,017 --> 00:23:53,000
-Bekah: We should -- is- is
-Kirk around? Can we bring Kirk
+Bekah: We should -- is- is Kirk
+around? Can we bring Kirk
 
-459
+594
 00:23:53,000 --> 00:23:53,307
 on?
 
-460
+595
 00:23:54,326 --> 00:24:00,000
 Dan: I don't know. It is Kirk
 Day.
 
-461
+596
 00:24:01,000 --> 00:24:02,606
 Bekah: Which is why we started.
 
-461
+597
 00:24:02,606 --> 00:24:06,000
 Dan: He responded to [inaudible]
 well, that was 20 minutes ago,
 
-462
+598
 00:24:06,000 --> 00:24:09,000
 I guess. Are you DM him? Or
 should I DM him?
 
-463
+599
 00:24:09,000 --> 00:24:09,700
 Bekah: I DMed him.
 
-464
+600
 00:24:09,700 --> 00:24:12,000
 Dan: Okay. We'll see if we can
 get Kirk on here.
 
-463
+601
 00:24:12,000 --> 00:24:14,395
 Bekah: Our celebrity. Our
 resident celebrity.
 
-465
+602
 00:24:15,416 --> 00:24:20,027
 Dan: It'll be funny. Because
 once we get another person on
 
-466
+603
 00:24:20,027 --> 00:24:24,000
 this call, you and me, we'll be
 in one box. And Kirk will be in
 
-467
+604
 00:24:24,000 --> 00:24:25,000
 another one [laughs].
 
-468
+605
 00:24:25,000 --> 00:24:25,300
 Bekah: Yeah.
 
-469
+606
 00:24:26,000 --> 00:24:27,700
 Dan: Oh, man. It's- it's crazy.
 It's crazy.
 
-467
+607
 00:24:28,000 --> 00:24:31,342
 Bekah: Kirk is at work. What's
 work? Can people do that?
 
-469
+608
 00:24:32,662 --> 00:24:37,192
 Dan: Don't they know it's Kirk
 Day? I'm pretty sure they do.
 
-470
+609
 00:24:37,192 --> 00:24:39,000
 Because they is --
 
-471
+610
 00:24:38,342 --> 00:24:40,981
-Bekah: Oh, I mean, maybe we
-can have any Kirk. Nick has
+Bekah: Oh, I mean, maybe we can
+have any Kirk. Nick has
 
-472
+611
 00:24:40,981 --> 00:24:41,500
 asked. That's a good question.
 
-473
+612
 00:24:41,500 --> 00:24:42,000
 Dan: Ooh.
 
-474
+613
 00:24:42,000 --> 00:24:46,000
 Bekah: So, in our Slack right
 now, most of us have put our
 
-474
+614
 00:24:46,000 --> 00:24:50,082
 profile down, flipped it, and
 reversed it. But with Kirk's --
 
-476
+615
 00:24:50,082 --> 00:24:52,000
 Dan: Huh. I see him. Kiirk.
 
-477
+616
 00:24:52,000 --> 00:24:53,000
 Bekah: Kiirk.
 
-478
+617
 00:24:52,500 --> 00:24:55,000
 Dan: Alright, alright. Hang on
 there a second. I'll
 
-479
+618
 00:24:55,000 --> 00:24:59,500
 [inaudible]. Alright. We're
 gonna try to get Kirk in to
 
-480
+619
 00:24:59,500 --> 00:24:59,700
 join --
 
-481
+620
 00:24:59,700 --> 00:25:01,700
 Bekah: We're doing out best. If
 we disappoint you-
 
-477
+621
 00:25:01,300 --> 00:25:03,500
 Dan: I just have- I just have to
 remember how, you know, work
 
-478
+622
 00:25:03,500 --> 00:25:04,000
 this [inaudible].
 
-479
+623
 00:25:04,000 --> 00:25:06,402
 Bekah: -we're sorry. We're doing
 our best
 
-478
+624
 00:25:06,402 --> 00:25:08,000
 to bring our celebrity on the
 stream.
 
-479
+625
 00:25:08,000 --> 00:25:09,000
 Dan: Him is celebrity.
 
-479
+626
 00:25:09,007 --> 00:25:11,612
 Bekah: At least take -- 10 fakes
 in- in the
 
-480
+627
 00:25:11,622 --> 00:25:14,800
 chat as well. I wanna shoutout
 to Abbey Perini because she
 
-482
+628
 00:25:14,801 --> 00:25:18,000
 DMed me last night. She was
 like, "After midnight, put up
 
-483
+629
 00:25:18,000 --> 00:25:22,700
 this in your profile." So, Abbey
 has been an amazing observer of
 
-485
+630
 00:25:22,700 --> 00:25:26,000
 Kirk Day, and I could not have
 asked for anything better.
 
-486
+631
 00:25:26,000 --> 00:25:29,300
 Dan: Oh, breakout rooms. I don't
 think we need breakout rooms.
 
-487
+632
 00:25:28,700 --> 00:25:31,500
 Bekah: We don't want breakout
 [inaudible] [all chuckle] --
 
-486
+633
 00:25:31,500 --> 00:25:32,700
 where are we breaking out to?
 
-487
+634
 00:25:33,000 --> 00:25:35,000
 Dan: I was trying to turn off
 the [inaudible].
 
-487
+635
 00:25:34,300 --> 00:25:37,700
 Bekah: Will the real slim Kirk
 please stand up? Yes. Oh, my
 
-488
+636
 00:25:37,700 --> 00:25:42,300
 goodness. We definitely need to
 find more ways to put Kirk into
 
-489
+637
 00:25:42,300 --> 00:25:42,686
 music.
 
-490
+638
 00:25:43,106 --> 00:25:46,586
 Dan: All right. Kirk said, he
 can join in three minutes. So-
 
-491
+639
 00:25:46,586 --> 00:25:46,800
 Bekah: Should we-
 
-492
+640
 00:25:46,700 --> 00:25:47,700
 Dan: -we have -- we --
 [unintelligible].
 
-493
+641
 00:25:46,800 --> 00:25:48,500
 Bekah: -tell jokes? Tell joke.
 Joke.
 
-494
+642
 00:25:48,500 --> 00:25:50,700
 Dan: I don't -- I'm not -- we
 just talk about for --
 
-492
+643
 00:25:50,700 --> 00:25:52,586
 before. I don't know jokes. I
 can't remember them.
 
-494
+644
 00:25:52,586 --> 00:25:56,457
 Bekah: All right. I'll tell my
 joke. Have you all [laughs]
 
-495
+645
 00:25:56,457 --> 00:25:57,146
 [inaudible] about pizza?
 
-496
+646
 00:25:59,916 --> 00:26:00,936
 Dan: Nope. I haven't heard that
 one.
 
-497
+647
 00:26:03,817 --> 00:26:05,616
 Bekah: [Laughs] Nevermind. It's
 too cheesy for pizza.
 
-498
+648
 00:26:09,717 --> 00:26:10,106
 Dan: Oh, man.
 
-499
+649
 00:26:11,247 --> 00:26:14,517
 Bekah: When we do the podcast,
 Dan always wants me to adjust my
 
-500
+650
 00:26:14,517 --> 00:26:18,000
 microphone. And so then, I try
 and tell him jokes, which he
 
-501
+651
 00:26:18,000 --> 00:26:18,537
 ignores
 
-502
+652
 00:26:18,537 --> 00:26:22,676
 all of the time. And then some
 of our guests are nice enough to
 
-503
+653
 00:26:22,676 --> 00:26:25,700
 laugh. So, if you come on the
 podcast, please laugh at my
 
-505
+654
 00:26:25,700 --> 00:26:28,000
 jokes and roll your eyes at Dan.
 
-506
+655
 00:26:28,000 --> 00:26:29,000
 Dan: Don't encourage her.
 
-507
+656
 00:26:29,500 --> 00:26:33,000
 Bekah: Please encourage me
 [laughs]. In my keynote-
 
-508
+657
 00:26:33,000 --> 00:26:33,300
 Dan: You know --
 
-507
+658
 00:26:33,116 --> 00:26:36,000
 Bekah: -talk that I'm giving in
 July, I'm just telling jokes for
 
-509
+659
 00:26:36,000 --> 00:26:38,606
 15 minutes straight because I
 can do whatever I want.
 
-510
+660
 00:26:38,606 --> 00:26:41,817
 Dan: That'll -- that's true.
 You're the keynote speaker. So,
 
-511
+661
 00:26:41,817 --> 00:26:44,000
 that'll be your first and only
 time being a keynote speaker
 
-512
+662
 00:26:44,000 --> 00:26:44,500
 [all laugh].
 
-513
+663
 00:26:44,500 --> 00:26:47,000
 Bekah: But is it worth it?
 
-514
+664
 00:26:47,000 --> 00:26:49,076
 Dan: Oh, Joe said I should fire
 you again -- wait! I did
 
-512
+665
 00:26:49,076 --> 00:26:51,300
 not fire you [Bekah laughs]. I
 reject the promise. I reject it!
 
-513
+666
 00:26:51,300 --> 00:26:55,257
 God, they keep trying to trick
 me!
 
-513
+667
 00:26:55,257 --> 00:27:01,500
 Bekah: Can't fire me anymore
 [laughs]. All right. But if
 
-514
+668
 00:27:01,500 --> 00:27:02,227
 anybody else
 
-515
+669
 00:27:02,227 --> 00:27:05,500
 has jokes, please put them in
 the chat and then I will deliver
 
-516
+670
 00:27:05,500 --> 00:27:05,700
 them because I'm-
 
-517
+671
 00:27:05,700 --> 00:27:06,500
 Dan: You know what?
 
-518
+672
 00:27:06,500 --> 00:27:07,300
 Bekah: -very good at it.
 
-518
+673
 00:27:07,567 --> 00:27:10,000
 Dan: She needs to deliver them
 because you are the worst joke
 
-519
+674
 00:27:10,000 --> 00:27:11,166
 receiver in
 
-519
+675
 00:27:11,166 --> 00:27:13,146
 the world. You know what she
 does? Yeah. You know you do,
 
-520
+676
 00:27:13,146 --> 00:27:15,700
-when you -- when I asked you
-jo- when I've like, I have --
+when you -- when I asked you jo-
+when I've like, I have --
 
-522
+677
 00:27:15,700 --> 00:27:19,000
 there's been times where I've,
 like, pulled out some jokes.
 
-523
+678
 00:27:19,000 --> 00:27:20,000
 Bekah: Oh, yeah?
 
-523
+679
 00:27:20,000 --> 00:27:21,500
 Dan: Yeah. Because I know that
 you appreciate them-
 
-524
+680
 00:27:21,500 --> 00:27:21,700
 Bekah: Mm-hmm.
 
-524
+681
 00:27:22,000 --> 00:27:25,311
 Dan: -but she try -- she guesses
 the answers. She like -- she
 
-525
+682
 00:27:25,311 --> 00:27:27,216
 didn't say, "I don't know.
 What?" She, like,
 
-526
+683
 00:27:27,936 --> 00:27:31,000
 tries to, like, it's a riddle.
 [Laughs] You are, right? Like --
 
-527
+684
 00:27:31,000 --> 00:27:32,000
 Bekah: Isn't that how everybody
 do it?
 
-527
+685
 00:27:31,500 --> 00:27:35,000
 Dan: No. No. No-
 
-528
+686
 00:27:35,000 --> 00:27:35,700
 Bekah: So, something [??]-
 
-529
+687
 00:27:35,700 --> 00:27:36,300
 Dan: -it's not.
 
-530
+688
 00:27:36,300 --> 00:27:38,700
 Bekah: -"Oh no, Dan. I don't
 know. Can you tell me the
 
-528
+689
 00:27:38,700 --> 00:27:40,000
 answer [laughs]?"
 
-529
+690
 00:27:40,626 --> 00:27:43,700
 Dan: No, that's not what -- what
 are you doing? You're fired
 
-530
+691
 00:27:43,700 --> 00:27:44,000
 [laughs].
 
-531
+692
 00:27:44,000 --> 00:27:46,297
 Bekah: [Laughs] Again?
 
-531
+693
 00:27:46,297 --> 00:27:51,000
 Dan: Not again. For the first
 time I have fired you [Bekah
 
-532
+694
 00:27:51,000 --> 00:27:52,000
 laughs]. [Sighs] Man.
 
-532
+695
 00:27:53,557 --> 00:27:56,257
 Bekah: See? Exactly. Thank you,
 Joe. Joe knows. It's not a joke.
 
-533
+696
 00:27:56,257 --> 00:27:57,366
 It's a challenge. Every joke is
 the challenge.
 
-534
+697
 00:27:59,297 --> 00:28:02,477
-Dan: That's not a -- mm-mm.
-That is not a joke.
+Dan: That's not a -- mm-mm. That
+is not a joke.
 
-535
+698
 00:28:02,656 --> 00:28:05,777
 Bekah: Well, but a joke then is
 like a story that you tell with
 
-536
+699
 00:28:05,777 --> 00:28:08,700
 a punchline at the end, in- in
 your sense of a joke is.
 
-537
+700
 00:28:07,500 --> 00:28:10,000
 Dan: I mean, you're- you're,
 like, stand up here? You're
 
-538
+701
 00:28:10,000 --> 00:28:11,000
 [all laugh] --
 
-539
+702
 00:28:11,000 --> 00:28:14,000
 Bekah: Yeah. Isn't that what
 everybody aspires to?
 
-540
+703
 00:28:14,500 --> 00:28:20,656
 Dan: Oh, wait. Kirk here. Okay.
 Well, according to Kirk, one
 
-538
+704
 00:28:20,656 --> 00:28:23,300
 minute left. So, yeah. We'll
 see.
 
-539
+705
 00:28:23,300 --> 00:28:24,500
 Bekah: One minute. T-minus one
 minute.
 
-540
+706
 00:28:24,500 --> 00:28:27,700
 Dan: Oh, Kirk was not consulted
 at all for any of this. That is
 
-539
+707
 00:28:27,700 --> 00:28:32,500
 true. I try not to consult Kirk
 at a time on things where --
 
-541
+708
 00:28:32,656 --> 00:28:33,136
 Bekah: We'd-
 
-542
+709
 00:28:32,700 --> 00:28:33,700
 Dan: He- he- he --
 
-543
+710
 00:28:33,500 --> 00:28:34,300
 Bekah: -somebody be reasonable
 [laughs].
 
-542
+711
 00:28:34,300 --> 00:28:39,500
 Dan: Yeah [laughs]. Yeah, right,
 exactly. Or, you know, where he
 
-543
+712
 00:28:39,500 --> 00:28:40,365
 might have time to
 
-544
+713
 00:28:40,366 --> 00:28:44,000
 think about whether he wants to
 engage with us. We try to- try
 
-545
+714
 00:28:44,000 --> 00:28:47,000
 to pull him in, you know, before
 he has a chance to, you know?
 
-546
+715
 00:28:47,300 --> 00:28:48,221
 Bekah: Yeah, no. We --
 
-547
+716
 00:28:48,221 --> 00:28:50,000
 Dan: Avoid my ridiculousness.
 
-548
+717
 00:28:50,000 --> 00:28:53,300
 Bekah: Joe, yes. We do need a
 scoreboard. Maybe that will be
 
-549
+718
 00:28:53,300 --> 00:28:54,700
 next month monthly challenge --
 
-550
+719
 00:28:53,700 --> 00:28:55,300
 Dan: Alright. So far it counts
 as one.
 
-551
+720
 00:28:56,000 --> 00:28:58,872
 Bekah: 97 and counting.
 
-550
+721
 00:29:01,061 --> 00:29:05,231
 Dan: [Chuckles] Oh, god. How did
 I not see that coming? Honestly.
 
-551
+722
 00:29:05,741 --> 00:29:08,442
 Bekah: I don't know. I didn't
 even think about it. And so we
 
-552
+723
 00:29:08,442 --> 00:29:10,000
 started talking and you brought
 it up.
 
-553
+724
 00:29:11,000 --> 00:29:12,000
 Dan: I don't think it was me.
 
-554
+725
 00:29:14,500 --> 00:29:16,000
 Bekah: Yes. A Slack channel-
 
-555
+726
 00:29:16,000 --> 00:29:16,700
 Dan: Yeah, definitely.
 
-553
+727
 00:29:17,000 --> 00:29:20,352
 Bekah: -or a Slack bot that
 posts every time that Dan fires
 
-554
+728
 00:29:20,352 --> 00:29:20,500
 me.
 
-554
+729
 00:29:20,352 --> 00:29:24,001
 Dan: Hmm. How about a Slack
 button that just announces that
 
-555
+730
 00:29:24,001 --> 00:29:24,571
 Bekah is fired again?
 
-556
+731
 00:29:25,922 --> 00:29:26,200
 Bekah: Everybody-
 
-557
+732
 00:29:26,200 --> 00:29:29,000
 Dan: That- that- that I'm- that
 I'm-
 
-558
+733
 00:29:26,300 --> 00:29:30,500
 Bekah: -just continuously fires
 me over and over [Dan laughs].
 
-557
+734
 00:29:30,500 --> 00:29:32,653
 It's okay. Just keep firing me.
 It's fine.
 
-558
+735
 00:29:33,700 --> 00:29:34,000
 Dan: Hm.
 
-559
+736
 00:29:35,000 --> 00:29:39,000
 Bekah: Kirk just preparing to be
 up here. Yeah, he probably --
 
-559
+737
 00:29:39,000 --> 00:29:41,300
 sorry, Kirk, we're sorry that
 you have to prepare for us
 
-561
+738
 00:29:41,300 --> 00:29:41,500
 [laughs].
 
-562
+739
 00:29:41,500 --> 00:29:42,000
 Kirk: Yeah.
 
-563
+740
 00:29:42,300 --> 00:29:44,500
 Bekah: We were trying to send a
 drone that would just go scoop
 
-563
+741
 00:29:44,500 --> 00:29:45,000
 up Kirk-
 
-564
+742
 00:29:44,700 --> 00:29:46,000
 Dan: Oh, how we gonna do this?
 
-565
+743
 00:29:44,800 --> 00:29:47,067
 Bekah: -and bring him to
 Cleveland.
 
-564
+744
 00:29:47,817 --> 00:29:51,686
 Dan: Well, maybe Zoom will cut
 out the echo. I was just
 
-565
-00:29:51,686 --> 00:29:51,500
+745
+00:29:51,686 --> 00:29:51,687
 thinking-
 
-566
+746
 00:29:51,500 --> 00:29:51,700
 Bekah: Oh.
 
-567
+747
 00:29:51,700 --> 00:29:56,000
 Dan: -I would have headphones.
 And then I was -- I don't know
 
-566
+748
 00:29:56,000 --> 00:30:01,700
 how to do that, really. We're
 just gonna try it. And I'm gonna
 
-568
+749
 00:30:01,700 --> 00:30:05,300
-count on you guys to tell us
-if there's a bad echo. Cuz I'm
+count on you guys to tell us if
+there's a bad echo. Cuz I'm
 
-570
+750
 00:30:05,300 --> 00:30:07,000
 just gonna play it over the
 speakers. And because Zoom is
 
-572
+751
 00:30:07,000 --> 00:30:09,000
 actually -- usually pretty good
 at that. Like-
 
-573
+752
 00:30:09,000 --> 00:30:10,500
 Bekah: One headphone in your ear
 and one headphone in my ear.
 
-574
+753
 00:30:10,500 --> 00:30:13,000
 Dan: I mean, if that's all we
 have to do, I -- you know, we
 
-573
+754
 00:30:13,000 --> 00:30:17,300
 can do AirPods or something. But
 like, that'll be annoying. I
 
-574
+755
 00:30:17,300 --> 00:30:23,000
 have -- I'm trying to think if
 there's any other ... solution.
 
-575
+756
 00:30:23,000 --> 00:30:27,500
 But literally, this is the first
 time I've ever sat next to
 
-576
+757
 00:30:27,500 --> 00:30:28,000
 somebody-
 
-577
+758
 00:30:28,000 --> 00:30:29,700
 Bekah: Okay. So, I -- here's --
 
-578
+759
 00:30:28,300 --> 00:30:31,047
 Dan: -and- and try to be on- be
 on, you know, camera.
 
-577
+760
 00:30:31,166 --> 00:30:35,000
 Bekah: I mean, if I have my
 computer, I can-
 
-578
+761
 00:30:35,000 --> 00:30:35,500
 Dan: Yeah.
 
-579
+762
 00:30:35,500 --> 00:30:36,300
 Bekah: -put on my AirPods and --
 
-579
+763
 00:30:35,700 --> 00:30:38,727
 Dan: I mean, like, you can go on
 the other fucking room and do
 
-580
+764
 00:30:38,727 --> 00:30:38,936
 that, like --
 
-580
+765
 00:30:39,000 --> 00:30:42,146
 oh, sorry. I did not mean to
 curse, but she made me have two
 
-581
+766
 00:30:42,146 --> 00:30:47,366
 beers. And she, you know, she
 forced me to do it. And -- which
 
-583
+767
 00:30:47,366 --> 00:30:49,196
 I've been meaning to talk to HR
 about, and they said you're
 
-584
+768
 00:30:49,196 --> 00:30:52,500
 fired, so ... [all laugh]. I
 would --
 
-585
+769
 00:30:52,500 --> 00:30:53,500
 Bekah: Fired again [laughs].
 
-586
+770
 00:30:53,500 --> 00:30:55,500
 Dan: The reason I swore was
 because, like,
 
-585
+771
 00:30:55,500 --> 00:30:58,700
 you going out somewhere else
 sounds not fun is my point.
 
-586
+772
 00:30:58,700 --> 00:30:59,300
 Bekah: I meant-
 
-587
+773
 00:30:59,300 --> 00:31:00,000
 Dan: I would be sad about that.
 
-588
+774
 00:30:59,700 --> 00:31:03,300
 Bekah: -just have my computer,
 and log on, and I would sit
 
-587
+775
 00:31:03,300 --> 00:31:04,000
 here-
 
-588
+776
 00:31:03,500 --> 00:31:05,800
 Dan: Hm. I feel like you- I feel
 like you ended up getting a --
 
-589
+777
 00:31:04,000 --> 00:31:06,477
 Bekah: -but just so I could put
 the sound in my ear.
 
-588
+778
 00:31:06,477 --> 00:31:08,000
 Dan: I feel like you'd get a
 delay, plus you'd hear me
 
-590
+779
 00:31:08,000 --> 00:31:14,000
 through there too. And through
 here too [laughs], you know?
 
-591
+780
 00:31:14,000 --> 00:31:15,300
 Bekah: Mm-hmm. Mm-hmm.
 
-592
+781
 00:31:15,300 --> 00:31:18,500
 Dan: So, we're gonna try it with
 [inaudible].
 
-591
+782
 00:31:19,257 --> 00:31:21,000
 Bekah: Do they have, like,
 covers for your AirPods that
 
-592
+783
 00:31:21,000 --> 00:31:22,796
 you're sharing them for someone
 else? Like, you know how, like,
 
-593
+784
 00:31:22,796 --> 00:31:23,000
 they-
 
-594
+785
 00:31:23,000 --> 00:31:24,000
 Dan: Oh, yeah. We couldn't --
 
-594
+786
 00:31:24,116 --> 00:31:25,000
 Bekah: -have like the tongue
 depressor-
 
-595
+787
 00:31:25,000 --> 00:31:26,500
 Dan: My airp- yeah, yeah.
 
-595
+788
 00:31:25,700 --> 00:31:28,000
 Bekah: -and they cover it? Or
 like the ear thing, they put a
 
-596
+789
 00:31:28,000 --> 00:31:30,747
 little thing? Do they have one
 of those for your AirPods?
 
-597
+790
 00:31:31,977 --> 00:31:35,500
 Dan: The -- oh, yeah. That's --
 as soon as I thought- thought of
 
-598
+791
 00:31:35,500 --> 00:31:37,317
 that, that's where, like, my
 
-599
+792
 00:31:37,317 --> 00:31:39,000
 AirPods are, like, gross right
 now. Like, I wouldn't wanna
 
-600
+793
 00:31:39,000 --> 00:31:42,000
 share that with anybody. So that
 would be an embarrassing thing
 
-601
+794
 00:31:42,000 --> 00:31:42,566
 to do as well [Bekah laughs].
 
-602
+795
 00:31:43,767 --> 00:31:50,156
 There has to be some sort of
 like ... I dunno. I feel
 
-603
+796
 00:31:50,156 --> 00:31:52,000
 like back in the day, they used
 to have a lot of cool things of
 
-605
+797
 00:31:52,000 --> 00:31:55,076
 where you'd split the, you know?
 I probably, honestly have --
 
-606
+798
 00:31:55,076 --> 00:31:56,700
 Bekah: Did they have lots of
 cool things?
 
-606
+799
 00:31:56,700 --> 00:31:57,355
 Dan: Yeah. Where they'd have
 
-607
+800
 00:31:57,356 --> 00:32:00,057
 a little splitter. So you have
 your iPod and the cord with the
 
-608
+801
 00:32:00,057 --> 00:32:02,000
 two things, and then you could-
 could sit-
 
-609
+802
 00:32:01,000 --> 00:32:02,000
 Bekah: Oh, I didn't have an
 iPod.
 
-609
+803
 00:32:02,000 --> 00:32:04,707
 Dan: -in those cars. You could
 sit next to your friend in the
 
-609
+804
 00:32:04,707 --> 00:32:06,700
 -- or in the bus or the car and
 both just do the same thing.
 
-610
+805
 00:32:06,700 --> 00:32:06,911
 Bekah: What?
 
-610
+806
 00:32:06,911 --> 00:32:08,000
 Dan: Yeah.
 
-611
+807
 00:32:08,000 --> 00:32:08,700
 Bekah: I said --
 
-611
+808
 00:32:08,700 --> 00:32:11,000
 Dan: But those were recorded,
 you know? They were like --
 
-612
+809
 00:32:11,000 --> 00:32:12,000
 Bekah: Old people?
 
-612
+810
 00:32:12,000 --> 00:32:16,000
 Dan: No. Fo-for like cool kids
 in high school that listened to
 
-613
+811
 00:32:16,000 --> 00:32:17,700
 cool music and had cool friends.
 
-614
+812
 00:32:17,700 --> 00:32:19,900
 Bekah: I was not a cool kid with
 cool friends in high school
 
-615
+813
 00:32:19,900 --> 00:32:20,000
 [laughs].
 
-616
+814
 00:32:20,000 --> 00:32:23,000
 Dan: Alright. I didn't have it
 either, so ... it just seemed
 
-617
+815
 00:32:23,000 --> 00:32:23,382
 cool [all laugh].
 
-618
+816
 00:32:23,700 --> 00:32:24,300
 Kirk Shillingford: What?
 [Inaudible].
 
-614
+817
 00:32:24,300 --> 00:32:28,300
 Bekah: Can watch the other cool
 kids. Ooh, Kirk is talking. It's
 
-615
+818
 00:32:28,300 --> 00:32:29,000
 said up there.
 
-616
+819
 00:32:29,000 --> 00:32:29,500
 Dan: Oh, oh.
 
-617
+820
 00:32:29,500 --> 00:32:30,000
 Bekah: Where is he?
 
-618
+821
 00:32:30,000 --> 00:32:32,000
 Dan: Kirk, are you here?
 
-616
+822
 00:32:32,000 --> 00:32:33,000
 Kirk:  I mean, I can see you.
 
-617
+823
 00:32:33,000 --> 00:32:34,000
 Dan: Hey! There you are
 [laughs].
 
-618
+824
 00:32:33,500 --> 00:32:34,000
 Bekah: Kirk!
 
-619
+825
 00:32:35,700 --> 00:32:37,500
 Kirk: I want you to know, like
 --
 
-617
+826
 00:32:37,500 --> 00:32:39,000
 Bekah: [Laughs] I just shouted.
 
-618
+827
 00:32:39,000 --> 00:32:39,700
 Dan: It's Kirk!
 
-618
-00:32:39,700 --> 00:32:43,500
+828
+00:32:39,700 --> 00:32:41,600
 Kirk: I, like, feel watching the
-stream while I was getting ready.
+stream while I was getting
 
-620
+829
+00:32:41,600 --> 00:32:43,500
+ready.
+
+830
 00:32:43,500 --> 00:32:46,500
 And then, there was a moment
 where I'm like, "This is --
 
-622
+831
 00:32:46,500 --> 00:32:50,000
 there's a lot of going on here.
 I don't know- I don't know where
 
-623
+832
 00:32:50,000 --> 00:32:55,500
 I fit in. I don't have any
 jokes. And I don't have, like,
 
-624
+833
 00:32:55,500 --> 00:32:59,000
 any jokes [inaudible] rule
 formats." So --
 
-625
+834
 00:32:59,000 --> 00:33:01,000
 Bekah: But you're the best. So
 --
 
-625
+835
 00:33:01,500 --> 00:33:06,500
-Kirk: You know? Bekah, I- I
-feel like, what do you think are
+Kirk: You know? Bekah, I- I feel
+like, what do you think are
 
-626
+836
 00:33:06,500 --> 00:33:09,000
 jokes and not what other
 [inaudible] [laughs].
 
-627
+837
 00:33:09,500 --> 00:33:10,000
 Bekah: [All laugh] Oh, no!
 
-626
+838
 00:33:11,500 --> 00:33:14,000
 Kirk: I just feel like you've
 taken, like, stand-up and
 
-627
+839
 00:33:14,000 --> 00:33:18,500
 competition, and you, like, flip
 them together instead that is
 
-628
+840
 00:33:18,500 --> 00:33:23,500
 all of jokes [all laugh].
 [Inaudible]. There's more than
 
-629
+841
 00:33:23,500 --> 00:33:24,000
 jokes.
 
-627
+842
 00:33:24,000 --> 00:33:26,000
 Dan: Oh, Kirk. I'm so glad
 you're here.
 
-628
+843
 00:33:27,500 --> 00:33:28,000
 Kirk: I just --
 
-629
+844
 00:33:28,000 --> 00:33:30,326
 Dan: I think that's -- that was
 decades ago. I know it was
 
-629
+845
 00:33:30,326 --> 00:33:33,626
 decades ago because it was high
 school. Thank you for putting
 
-630
+846
 00:33:33,626 --> 00:33:35,000
 that out there. I appreciate
 that.
 
-631
+847
 00:33:35,000 --> 00:33:36,000
 Kirk: Decades?
 
-632
+848
 00:33:36,000 --> 00:33:38,500
 Dan: Oh, god.
 
-633
+849
 00:33:38,500 --> 00:33:39,000
 Bekah: Let's start.
 
-634
+850
 00:33:39,000 --> 00:33:41,000
 Dan: All right. Everybody else
 has said there's no audio
 
-631
+851
 00:33:41,000 --> 00:33:42,000
 issues.
 
-632
+852
 00:33:42,000 --> 00:33:42,500
 Bekah: Yay!
 
-633
+853
 00:33:43,000 --> 00:33:43,916
 Dan: We are good.
 
-632
+854
 00:33:44,277 --> 00:33:47,000
 Bekah: We did it. We got the
 celebrity of the year here.
 
-633
+855
 00:33:47,000 --> 00:33:48,896
 Welcome. It's been a great year.
 
-634
+856
 00:33:48,500 --> 00:33:51,000
 Dan: The- the celebrity of
 multiverse [chuckles].
 
-635
+857
 00:33:51,500 --> 00:33:51,700
 Bekah: Yeah.
 
-635
+858
 00:33:51,700 --> 00:33:55,346
 Kirk: I did -- this entire day,
 I've just been seeing threads
 
-637
+859
 00:33:55,346 --> 00:33:58,000
 ongoing. I don't remember
 talking though. No.
 
-638
+860
 00:33:58,000 --> 00:34:00,700
 Dan: [Laughs] Yeah. I was --
 I've been having the opposite
 
-639
+861
 00:34:00,700 --> 00:34:02,576
 problem where I r- I read as
 
-639
+862
 00:34:02,576 --> 00:34:05,467
 reading through a thread and was
 like, "Oh, who wrote that? Oh,
 
-640
+863
 00:34:05,467 --> 00:34:06,000
 that was me." Like, it's [all
 laugh] --
 
-641
+864
 00:34:07,000 --> 00:34:08,700
 Bekah: Dan said, "I think we're
 at lunches [laughs]."
 
-642
+865
 00:34:08,700 --> 00:34:08,876
 [Inaudible].
 
-642
+866
 00:34:11,126 --> 00:34:15,000
 Kirk: It's -- this is ... again,
 I just wanna make the record
 
-643
+867
 00:34:15,000 --> 00:34:19,500
 clear that I was not consulted
 about any of this. I woke up,
 
-644
+868
 00:34:19,500 --> 00:34:23,186
 I saw it, I just assumed Slack
 wasn't working.
 
-646
+869
 00:34:24,000 --> 00:34:25,000
 Dan: [Dan and Bekah laugh] Yeah,
 it does that- it does that --
 
-645
+870
 00:34:24,746 --> 00:34:26,156
 Bekah: Nick Taylor, like,
 somebody would -- maybe read out
 
-646
+871
 00:34:26,156 --> 00:34:27,566
 was like,
 
-647
+872
 00:34:28,266 --> 00:34:30,746
 "I'm seeing pictures of Kirk."
 And Nick is like, "It happens
 
-648
+873
 00:34:30,746 --> 00:34:32,000
 sometimes." And it does. Like,
 sometimes-
 
-649
+874
 00:34:32,000 --> 00:34:32,300
 Dan: It does happen.
 
-650
+875
 00:34:32,300 --> 00:34:33,700
 Bekah: -Slack put other-
 
-651
+876
 00:34:32,700 --> 00:34:33,000
 Kirk: Yeah.
 
-649
+877
 00:34:33,777 --> 00:34:34,737
 Bekah: -people's pictures.
 
-650
+878
 00:34:35,500 --> 00:34:37,976
 Dan: Not upside down usually
 though.
 
-651
+879
 00:34:37,976 --> 00:34:39,700
 Bekah: No. And flipped it
 [inaudible] and reversed it.
 
-652
+880
 00:34:39,896 --> 00:34:42,567
 Kirk: Okay. So I'm gonna be
 clear. I was very dense. It
 
-653
+881
 00:34:42,567 --> 00:34:45,700
 took me way too long to figure
 out that's what that was. Again,
 
-654
+882
 00:34:45,700 --> 00:34:50,000
 I'm just -- I thought Slack was
 not working. And then I thought
 
-656
+883
 00:34:50,000 --> 00:34:50,567
 it was like,
 
-655
+884
 00:34:50,567 --> 00:34:54,597
 "Okay. Let's add one way for
 Kirk to distinguish himself
 
-656
+885
 00:34:54,597 --> 00:34:57,597
 from other people." But it
 wasn't even about me. Which I
 
-657
+886
 00:34:57,597 --> 00:34:58,000
 feel like it's the --
 
-657
+887
 00:34:58,000 --> 00:35:01,000
 Bekah: It's all about you. Every
 part of it is.
 
-658
+888
 00:35:01,000 --> 00:35:05,000
 Kirk: Kirk Day is about ...
 everyone. It's a- it's a VC
 
-659
+889
 00:35:05,000 --> 00:35:05,847
 event. I'm just-
 
-660
+890
 00:35:06,000 --> 00:35:06,500
 Bekah: It's about-
 
-661
+891
 00:35:06,500 --> 00:35:07,000
 Kirk: -just this small --
 
-662
+892
 00:35:07,000 --> 00:35:09,626
 Bekah: -celebrating how much we
 love Kirk.
 
-663
+893
 00:35:09,626 --> 00:35:10,500
 Dan: Yep. It's true.
 
-661
+894
 00:35:10,700 --> 00:35:11,000
 Kirk: No.
 
-662
+895
 00:35:12,356 --> 00:35:14,876
 Bekah: We're lucky that Missy
 Elliott responded to you. So we
 
-663
+896
 00:35:14,876 --> 00:35:18,507
 can remember every day -- it's
 like Valentine's day. Because
 
-664
+897
 00:35:18,507 --> 00:35:20,500
 some people don't like
 Valentine's day, cuz they're
 
-665
+898
 00:35:20,500 --> 00:35:21,027
 like, "What is this? It's
 
-665
-00:35:21,027 --> 00:35:25,500
+899
+00:35:21,027 --> 00:35:23,263
 a commercial holiday to sell us
-chocolate, and flowers, and cars."
+chocolate, and flowers, and
 
-666
+900
+00:35:23,263 --> 00:35:25,499
+cars."
+
+901
 00:35:25,500 --> 00:35:28,700
 And -- but, it's also a day to,
 like, remind you to stop
 
-667
+902
 00:35:28,700 --> 00:35:33,000
 and think like, "Oh, I'm going
 to tell this person that I
 
-668
+903
 00:35:33,000 --> 00:35:37,700
 love them today," right? And so,
 like, we often forget to tell
 
-670
+904
 00:35:37,700 --> 00:35:41,000
 you every single day that we
 love you, Kirk. So this is our
 
-671
+905
 00:35:41,000 --> 00:35:45,000
 Kirk Valentine's Day slash Missy
 Elliot Day.
 
-672
+906
 00:35:45,000 --> 00:35:46,000
 Dan: We do love you, Kirk.
 
-673
-00:35:46,000 -->00:35:47,000
+907
+00:35:46,000 --> 00:35:47,000
 Bekah: We love you.
 
-673
+908
 00:35:47,500 --> 00:35:50,000
 Kirk: Ah, see? I wasn't prepared
 for this either. Go back to
 
-674
+909
 00:35:50,000 --> 00:35:52,000
 these jokes [Bekah and Dan
 laugh]. No, I don't wanna any --
 
-675
+910
 00:35:52,000 --> 00:35:53,700
 I didn't sign up for any real
 emotions here.
 
-674
+911
 00:35:52,500 --> 00:35:55,586
 Dan: Kirk, Kirk, since it's Kirk
 Day, do you wanna fire Bekah
 
-675
+912
 00:35:55,586 --> 00:35:56,000
 too?
 
-675
+913
 00:35:56,786 --> 00:35:57,000
 Kirk: No.
 
-676
+914
 00:35:58,000 --> 00:35:58,500
 Dan: [Laughs] Alright.
 
-677
+915
 00:35:58,500 --> 00:35:59,000
 Kirk: I mean-
 
-676
+916
 00:35:59,000 --> 00:35:59,500
 Bekah: Thank you.
 
-677
+917
 00:36:00,000 --> 00:36:00,300
 Dan: Alright.
 
-678
+918
 00:36:00,500 --> 00:36:00,700
 Bekah: Thank you.
 
-677
+919
 00:36:01,000 --> 00:36:05,637
-Kirk: -I feel like [inaudible]
-I have to be the one person who
+Kirk: -I feel like [inaudible] I
+have to be the one person who
 
-676
+920
 00:36:05,637 --> 00:36:06,416
 doesn't fire you.
 
-677
+921
 00:36:06,416 --> 00:36:08,000
 Dan: Alright. I guess it's --
 
-678
+922
 00:36:08,000 --> 00:36:10,700
 Bekah: How many people do you
 think have fired me?
 
-679
+923
 00:36:10,947 --> 00:36:13,677
 Kirk: I mean, just based on the
 chat response, people seem to be
 
-680
+924
 00:36:13,677 --> 00:36:18,700
 really into you being fired.
 Like, as much as like Kirk Day,
 
-681
+925
 00:36:18,700 --> 00:36:22,700
 like, on their tier list of
 events, Kirk Day, Bekah being
 
-682
+926
 00:36:22,700 --> 00:36:26,000
 fired, that's what the people
 want.
 
-683
+927
 00:36:26,967 --> 00:36:29,700
 Bekah: The people want me to be
 fired [Bekah and Dan laugh]?
 
-684
+928
 00:36:30,500 --> 00:36:31,000
 Kirk: I dunno.
 
-685
+929
 00:36:31,000 --> 00:36:33,000
 Bekah: I don't even know what to
 do. I'm gonna have to, like,
 
-684
+930
 00:36:33,000 --> 00:36:38,000
 think about this very hard on my
 two and a half hour drive home.
 
-685
+931
 00:36:38,000 --> 00:36:39,927
 Why everybody wants me to be
 fired?
 
-686
+932
 00:36:40,677 --> 00:36:44,000
 Kirk: Well, you seem to be like
 really enthused about it, to be
 
-687
+933
 00:36:44,000 --> 00:36:47,500
 honest. Cuz you're the one who
 brings it up. Dan doesn't bring
 
-688
+934
 00:36:47,500 --> 00:36:47,700
 it up.
 
-688
+935
 00:36:47,700 --> 00:36:50,367
 Bekah: No. I'm just shaming him.
 
-689
+936
 00:36:50,367 --> 00:36:52,000
 Kirk: It's like your origin
 story.
 
-690
+937
 00:36:52,000 --> 00:36:54,626
 Bekah: It is- it is my origin
 story [Dan and Bekah chuckle].
 
-691
+938
 00:36:58,407 --> 00:37:01,467
 Kirk: Not teaching, not the
 women who code, like, it's
 
-692
-00:37:01,467 --> 00:37:06,000
+939
+00:37:01,467 --> 00:37:03,733
 all started when Dan fired me.
-And then the passion live inside.
+And then the passion live
 
-693
+940
+00:37:03,733 --> 00:37:05,999
+inside.
+
+941
 00:37:06,500 --> 00:37:07,000
 Bekah: Listen, my --
 
-694
+942
 00:37:07,000 --> 00:37:09,700
 Kirk: The second time it
 happened, less [??] fire.
 
-693
+943
 00:37:10,000 --> 00:37:13,000
 Bekah: My other origin story is
 not a -- it's- it's not --
 
-695
+944
 00:37:13,077 --> 00:37:15,000
 it's rated PG-13.
 
-696
+945
 00:37:16,000 --> 00:37:17,000
 Dan: What?
 
-697
+946
 00:37:18,000 --> 00:37:20,000
 Bekah: Why I got into coding?
 
-696
+947
 00:37:20,700 --> 00:37:26,500
 Kirk: Oh, why did I get into
 coding? I didn't -- I was have
 
-697
+948
 00:37:26,500 --> 00:37:26,657
 to --
 
-697
+949
 00:37:26,657 --> 00:37:28,500
 Bekah: I mean, I can tell that
 one, but then people always feel
 
-698
+950
 00:37:29,146 --> 00:37:31,500
 awkward. Cuz, like, when someone
 asks you how you got into coding
 
-699
+951
 00:37:31,500 --> 00:37:34,500
 and you use the word vagina,
 they're suddenly like, all weird
 
-700
+952
 00:37:34,500 --> 00:37:34,800
 about it.
 
-701
+953
 00:37:34,800 --> 00:37:37,000
 Dan: Is that what gets you
 PG-13? I don't know [inaudible].
 
-702
+954
 00:37:37,300 --> 00:37:39,700
 Bekah: Yeah, for sure. I don't
 think you can say that in a PG
 
-701
+955
 00:37:39,700 --> 00:37:40,097
 movie [chuckles].
 
-702
+956
 00:37:40,700 --> 00:37:41,300
 Dan: Really?
 
-703
+957
 00:37:42,000 --> 00:37:42,300
 Kirk: I --
 
-704
+958
 00:37:42,300 --> 00:37:42,500
 Dan: I don't know.
 
-702
+959
 00:37:43,007 --> 00:37:46,000
 Bekah: You can drop one f-bomb
 in a PG-13 movie. So we're saw
 
-703
+960
 00:37:46,000 --> 00:37:47,500
 a PG-13 here. We're good.
 
-704
+961
 00:37:47,500 --> 00:37:47,700
 Dan: Boom.
 
-705
+962
 00:37:47,700 --> 00:37:48,407
 Bekah: Dan, watch yourself.
 
-704
+963
 00:37:50,456 --> 00:37:52,000
 Dan: What's gonna happen
 [chuckles]?
 
-705
+964
 00:37:52,300 --> 00:37:54,700
 Kirk: So, why would you really
 throw it all to Dan?
 
-706
+965
 00:37:54,700 --> 00:37:56,000
 Bekah: Because he already
 dropped one-
 
-707
+966
 00:37:56,000 --> 00:37:56,500
 Dan: That's true.
 
-708
+967
 00:37:56,500 --> 00:37:57,000
 Bekah: -today.
 
-709
+968
 00:37:57,000 --> 00:37:57,200
 Kirk: Oh.
 
-710
+969
 00:37:57,200 --> 00:37:58,700
 Bekah: He dropped one and only.
 
-711
+970
 00:37:58,700 --> 00:37:59,000
 Dan: Yeah.
 
-707
+971
 00:37:59,000 --> 00:38:01,106
 Bekah: He was like, "I'm gonna
 be the one that gets to drop
 
-708
+972
 00:38:01,106 --> 00:38:01,300
 it."
 
-708
+973
 00:38:01,300 --> 00:38:03,000
 Dan: It's -- cuz I was worried
 about you leaving.
 
-709
+974
 00:38:04,706 --> 00:38:06,700
-Kirk: Okay. Yeah. No. You're
-in Dan's house now. So you get,
+Kirk: Okay. Yeah. No. You're in
+Dan's house now. So you get,
 
-710
+975
 00:38:06,700 --> 00:38:07,500
 like, what's-
 
-711
+976
 00:38:07,500 --> 00:38:08,000
 Dan: It's not my house.
 
-712
+977
 00:38:07,600 --> 00:38:09,000
 Kirk: -where's the body?
 
-711
+978
 00:38:09,000 --> 00:38:11,500
 Dan: It is my office. It's
 office.
 
-712
+979
 00:38:11,500 --> 00:38:11,700
 Kirk: Oh.
 
-713
+980
 00:38:11,700 --> 00:38:12,451
 Bekah: It is an office.
 
-712
+981
 00:38:12,451 --> 00:38:14,846
 Dan: Yeah. It's actually
 Sprockets'
 
-713
+982
 00:38:14,936 --> 00:38:17,966
 office, which is who I do most
 of the work through. But I have
 
-715
+983
 00:38:17,967 --> 00:38:21,700
 my own, like ... well, I don't
 know this stuff. You know, I
 
-717
+984
 00:38:21,700 --> 00:38:23,817
 have my own room that is my
 office in the [inaudible].
 
-718
+985
 00:38:24,000 --> 00:38:25,500
 Kirk: I interpreted everything-
 
-719
+986
 00:38:25,000 --> 00:38:26,700
 Dan: What do you call that words
 of room? What's the word for-
 
-720
+987
 00:38:25,700 --> 00:38:28,500
 Kirk: -you've said as
 [inaudible] house-
 
-721
+988
 00:38:26,700 --> 00:38:28,000
 Dan: -that? Like, I have like --
 
-722
+989
 00:38:28,500 --> 00:38:29,000
 Kirk: -in a tree.
 
-719
+990
 00:38:28,700 --> 00:38:31,166
 Dan: There is -- there's a suite
 of offices.
 
-720
+991
 00:38:31,166 --> 00:38:31,300
 Bekah: Yes.
 
-721
+992
 00:38:32,500 --> 00:38:32,927
 Dan: And I have --
 
-720
+993
 00:38:32,927 --> 00:38:33,700
 Bekah: It's got its own little
 pod.
 
-721
+994
 00:38:33,700 --> 00:38:34,300
 Dan: I have one of them.
 
-721
+995
 00:38:34,700 --> 00:38:36,916
 Bekah: There's a conference room
 and a couple of offices.
 
-722
+996
 00:38:37,487 --> 00:38:38,687
 Kirk: I believe that you are
 both in a tree house. I don't
 
-724
+997
 00:38:39,887 --> 00:38:41,297
 believe anything you say.
 
-725
+998
 00:38:41,297 --> 00:38:42,226
 Bekah: I would like to be in a
 tree house.
 
-726
+999
 00:38:42,226 --> 00:38:47,700
 Dan: That would be cool. Emily
 and I went two weeks -- last
 
-727
+1000
 00:38:47,700 --> 00:38:48,987
 week? When was I gone?
 
-728
+1001
 00:38:48,987 --> 00:38:50,500
 I dunno. Two weeks ago, whatever
 it was-
 
-729
+1002
 00:38:50,500 --> 00:38:51,000
 Bekah: Oh, yeah.
 
-730
+1003
 00:38:51,500 --> 00:38:53,700
 Dan: -to Amish country and got a
 tree house like Airbnb-
 
-731
+1004
 00:38:53,700 --> 00:38:54,326
 Bekah: Oh, nice.
 
-730
+1005
 00:38:54,326 --> 00:38:57,515
 Dan: -it's like a newly built
 thing that was, like, well way
 
-731
+1006
 00:38:57,516 --> 00:39:00,000
 raised up in the trees and
 stuff. It was really cool. Yeah.
 
-733
+1007
 00:39:00,000 --> 00:39:01,646
 Highly recommend.
 
-734
+1008
 00:39:02,666 --> 00:39:05,697
 Bekah: Gemma and I drove through
 Amish country recently on
 
-736
+1009
 00:39:05,697 --> 00:39:07,500
 accident cuz I made a wrong
 turn.
 
-738
+1010
 00:39:06,000 --> 00:39:08,500
 Dan: Oh, yeah. That's always-
 that's always a great adventure.
 
-738
+1011
 00:39:08,000 --> 00:39:11,000
 Bekah: And we went for shopping.
 And I- I got some large plastic
 
-739
+1012
 00:39:11,000 --> 00:39:12,806
 bins for $3 each.
 
-739
+1013
 00:39:13,916 --> 00:39:14,967
 Kirk: Amish plastic bins?
 
-740
+1014
 00:39:15,447 --> 00:39:17,637
 Bekah: No. But there were $3
 [chuckles].
 
-741
+1015
 00:39:17,637 --> 00:39:20,097
 Dan: One thing I learned, this
 trip, lots of Amish people now
 
-742
+1016
 00:39:20,126 --> 00:39:23,786
 are into e-bikes, which was a
 surprise to me. But it was cool.
 
-743
+1017
 00:39:23,786 --> 00:39:25,000
 Bekah: Ooh. I don't think I see
 an e-bike.
 
-743
+1018
 00:39:24,266 --> 00:39:26,500
 Dan: And it made sense once I
 thought about it. So, like lots
 
-744
+1019
 00:39:26,500 --> 00:39:29,700
 of -- and it was honestly, there
 was a couple of men, mostly a
 
-745
+1020
 00:39:29,700 --> 00:39:34,000
 lot of women, riding around on
 the country highways. I mean the
 
-746
+1021
 00:39:34,000 --> 00:39:34,500
 same highways
 
-747
+1022
 00:39:34,500 --> 00:39:37,706
 that the- the buggies are riding
 on, but like -- but they're just
 
-748
+1023
 00:39:37,706 --> 00:39:40,376
 like -- and they usually had a
 little bike trailer, you know?
 
-749
+1024
 00:39:40,646 --> 00:39:44,300
 But they're just like flying
 down. I went on an el- on an
 
-750
+1025
 00:39:44,300 --> 00:39:44,831
 electric bike. It's cool.
 
-751
+1026
 00:39:44,831 --> 00:39:45,300
 Bekah: Mm. Interesting.
 
-752
+1027
 00:39:45,300 --> 00:39:45,500
 Dan: Yeah.
 
-750
+1028
 00:39:46,000 --> 00:39:48,911
 Kirk: Fun fact. Early in the
 history of bikes,
 
-752
+1029
 00:39:49,061 --> 00:39:52,751
 there was like a massive upsurge
 in popularity with women
 
-753
+1030
 00:39:53,112 --> 00:39:55,811
 because it gave them like assets
 to travel and, like, see their
 
-754
+1031
 00:39:55,811 --> 00:39:59,411
 friends without having to, like,
 go through their husbands. And
 
-756
+1032
 00:39:59,411 --> 00:40:02,172
 so, there was like a big, like,
 reactionary thing so that
 
-757
+1033
 00:40:02,351 --> 00:40:04,000
 people -- they were, like,
 published articles about, like,
 
-758
+1034
 00:40:04,000 --> 00:40:10,000
 the bicycle. Is it ruining your
 woman [laughs] to get them stay
 
-758
+1035
 00:40:10,000 --> 00:40:11,700
 home again? Is that how that
 goes?
 
-760
+1036
 00:40:13,322 --> 00:40:16,700
-I just- I just imagine some
-like do just like, "Argh! These
+I just- I just imagine some like
+do just like, "Argh! These
 
-761
+1037
 00:40:16,700 --> 00:40:19,541
 bicycles. They're hanging out
 with their friends!"
 
-763
+1038
 00:40:20,621 --> 00:40:21,500
 Bekah: I don't ride a bicycle.
 
-764
+1039
 00:40:22,000 --> 00:40:22,500
 Dan: What?
 
-765
+1040
 00:40:23,000 --> 00:40:24,000
 Bekah: I don't ride bicycles.
 
-766
+1041
 00:40:24,700 --> 00:40:26,500
 Kirk: You can't or you don't?
 
-767
+1042
 00:40:25,000 --> 00:40:26,000
 Dan: You don't know how? Or you
 can't?
 
-765
+1043
 00:40:27,251 --> 00:40:27,700
 Bekah: Well, both.
 
-766
+1044
 00:40:28,000 --> 00:40:28,811
 Dan: You don't know how to ride
 a bike?
 
-766
+1045
 00:40:28,811 --> 00:40:31,632
-Bekah: Well, I- I did. But
-then I fell off it too many
+Bekah: Well, I- I did. But then
+I fell off it too many
 
-767
+1046
 00:40:31,632 --> 00:40:33,000
 times. So I stopped.
 
-768
+1047
 00:40:32,500 --> 00:40:33,300
 Dan: [Inaudible].
 
-769
+1048
 00:40:33,000 --> 00:40:34,000
 Kirk: So, you did know how to
 ride a bike.
 
-770
+1049
 00:40:35,000 --> 00:40:38,500
 Bekah: I don't know. I mean, do
 you know how if you keep falling
 
-769
+1050
 00:40:38,500 --> 00:40:42,000
 off? I had a bunch of stitches
 in my elbow. See? There's still
 
-770
+1051
 00:40:42,000 --> 00:40:44,000
 scar there. I don't think you
 can see that on screen.
 
-772
+1052
 00:40:44,000 --> 00:40:44,700
 Dan: I can see it. It's there.
 
-773
+1053
 00:40:44,500 --> 00:40:46,000
 Bekah: Thank you. Thanks for
 confirming.
 
-774
+1054
 00:40:46,000 --> 00:40:46,700
 Dan: It's very tiny.
 
-775
+1055
 00:40:46,700 --> 00:40:50,000
 Bekah: It was larger, okay. For
 a long time [laughs].
 
-776
+1056
 00:40:50,000 --> 00:40:51,000
 Kirk: Not a contest.
 
-772
+1057
 00:40:51,000 --> 00:40:54,356
 Bekah: I once ran into a pole
 while riding on a bicycle.
 
-773
+1058
 00:40:57,000 --> 00:40:57,700
 I don't ride bicycles.
 
-774
+1059
 00:40:57,700 --> 00:41:01,000
 Kirk: [Inaudible], but the story
 --
 
-775
+1060
 00:40:57,800 --> 00:41:00,500
 Dan: [Inaudible].
 
-773
+1061
 00:41:02,097 --> 00:41:03,000
 Bekah: I was on a flat path.
 
-774
+1062
 00:41:03,000 --> 00:41:03,300
 Dan: Yeah.
 
-775
+1063
 00:41:05,000 --> 00:41:05,700
 Kirk: I can relate [inaudible].
 
-774
+1064
 00:41:05,500 --> 00:41:07,500
 Dan: I mean, there's like, I
 think -- I feel like you know
 
-775
+1065
 00:41:07,500 --> 00:41:10,000
 how. You're just not good at it.
 And that's fine. I mean, like,
 
-777
+1066
 00:41:10,000 --> 00:41:12,686
 you -- you're allowed to be not
 good at things, you know? But
 
-778
+1067
 00:41:12,686 --> 00:41:14,000
 you know how to ride a bike.
 That's my point.
 
-779
+1068
 00:41:14,300 --> 00:41:16,000
 Bekah: You're saying I'm not
 good at riding bike?
 
-780
+1069
 00:41:16,000 --> 00:41:18,867
 Dan: Yep. Challenge- challenge
 thrown down [chuckles].
 
-781
+1070
 00:41:18,867 --> 00:41:20,000
 Bekah: I just don't know how
 [chuckles].
 
-781
+1071
 00:41:20,000 --> 00:41:21,237
 Kirk: Wait. Can you swim?
 
-782
+1072
 00:41:22,166 --> 00:41:23,277
 Bekah: I'm a great swimmer.
 
-783
+1073
 00:41:23,907 --> 00:41:26,000
 Kirk: Okay. I'm just trying to
 figure out, like, on -- in a
 
-784
+1074
 00:41:26,000 --> 00:41:26,217
 triathlon, like-
 
-785
+1075
 00:41:26,217 --> 00:41:26,400
 Dan: Whoa.
 
-786
+1076
 00:41:26,500 --> 00:41:29,000
 Bekah: I was a lifeguard for
 like 10 years of my life.
 
-787
+1077
 00:41:28,000 --> 00:41:30,000
 Dan: She used- she used to,
 like, very well out there, Kirk.
 
-784
+1078
 00:41:30,000 --> 00:41:31,700
 Kirk: -where are you struggling?
 
-785
+1079
 00:41:32,000 --> 00:41:35,000
 Bekah: I taught children how to
 swim. I taught swim team.
 
-785
+1080
 00:41:35,000 --> 00:41:38,067
 Kirk: So it's like swimming,
 running, cycling.
 
-786
+1081
 00:41:39,027 --> 00:41:40,500
 Bekah: Mm, yes. Uh-huh. Yeah.
 
-787
+1082
 00:41:40,500 --> 00:41:41,000
 Kirk: Fair.
 
-788
+1083
 00:41:41,000 --> 00:41:42,476
 Bekah: That's it. I don't know.
 I probably would
 
-787
+1084
 00:41:42,476 --> 00:41:45,356
 not ride a skateboard. I tried
 to do that with my child's
 
-788
+1085
 00:41:45,356 --> 00:41:47,291
 skateboard, and I was like,
 "This is gonna break my hip."
 
-789
+1086
 00:41:47,291 --> 00:41:49,900
 Dan: It's gonna [inaudible].
 Yeah. I was just worried about
 
-790
+1087
 00:41:49,900 --> 00:41:50,000
 my [inaudible] --
 
-791
+1088
 00:41:50,000 --> 00:41:53,000
 Bekah: No sled riding. I- I once
 almost broke my hip sled riding.
 
-792
+1089
 00:41:53,000 --> 00:41:56,300
 I had to go to the emergency
 room. It wasn't broken, but gave
 
-793
+1090
 00:41:56,300 --> 00:41:58,000
 me lifelong problems.
 
-794
+1091
 00:41:58,500 --> 00:41:59,000
 Kirk: That's a lot.
 
-795
+1092
 00:41:58,700 --> 00:42:01,000
 Bekah: When I was- I was on a
 mattress. I sled rode on a
 
-794
+1093
 00:42:01,000 --> 00:42:02,500
 mattress. That was a bad idea.
 
-795
+1094
 00:42:02,500 --> 00:42:04,300
 Dan: So you were sledding, so
 much as mattress riding?
 
-796
+1095
 00:42:04,000 --> 00:42:05,000
 Bekah: Well, so --
 
-797
+1096
 00:42:05,000 --> 00:42:05,700
 Dan: That's a little different.
 
-795
+1097
 00:42:05,700 --> 00:42:08,300
 Bekah: I was, like, not good at
 sled riding. And so then these
 
-796
+1098
 00:42:08,300 --> 00:42:08,700
 boys in college-
 
-797
+1099
 00:42:08,700 --> 00:42:09,700
 Kirk: Okay. I'm in a --
 
-797
+1100
 00:42:09,000 --> 00:42:12,500
 Bekah: -they were like, "Hey,
 let's take this mattress and
 
-798
+1101
 00:42:12,500 --> 00:42:13,000
 we'll go-
 
-799
+1102
 00:42:13,000 --> 00:42:13,500
 Kirk: I mean --
 
-798
+1103
 00:42:13,500 --> 00:42:16,000
 Bekah: -on it. And you'll land
 on the mattress and it's soft."
 
-799
+1104
 00:42:16,000 --> 00:42:16,500
 Dan: Land?
 
-800
+1105
 00:42:16,500 --> 00:42:17,700
 Bekah: And that makes sense.
 
-801
+1106
 00:42:17,700 --> 00:42:18,500
 Kirk: I'm gonna take pause here.
 
-799
+1107
 00:42:17,967 --> 00:42:19,500
 Bekah: Well, okay. So there was
 a ramp-
 
-800
+1108
 00:42:19,500 --> 00:42:22,000
 Dan: Yeah! Alright. There's -- I
 knew there's more of the story.
 
-801
+1109
 00:42:20,300 --> 00:42:22,700
 Bekah: -but I was like, "Don't
 go over the ramp. They promised
 
-800
+1110
 00:42:22,700 --> 00:42:24,146
 they wouldn't go over the ramp
 and you know what-
 
-802
+1111
 00:42:24,146 --> 00:42:24,300
 Kirk: It does --
 
-803
+1112
 00:42:24,200 --> 00:42:26,907
 Bekah: -happened? Everybody
 ditched the mattress except me
 
-803
+1113
 00:42:26,907 --> 00:42:30,000
 and one other guy. And he landed
 on top of me and he was 200
 
-804
+1114
 00:42:30,000 --> 00:42:32,000
 pounds. I landed on my hip on
 the snow.
 
-805
+1115
 00:42:31,500 --> 00:42:32,700
 Dan: That is not sound good.
 
-806
+1116
 00:42:32,700 --> 00:42:33,700
 Bekah: It was not good.
 
-805
+1117
 00:42:33,700 --> 00:42:37,000
 Kirk: Your story started with,
 "I'm not good at sled riding."
 
-806
+1118
 00:42:37,000 --> 00:42:38,336
 But as far as
 
-806
+1119
 00:42:38,336 --> 00:42:41,456
 I'm aware -- now, remember where
 I live. So, I'm admittedly
 
-807
+1120
 00:42:41,456 --> 00:42:45,327
 ignorant of these things. But
 aren't you just -- isn't it
 
-808
+1121
 00:42:45,327 --> 00:42:47,277
 just like physics happening to
 you?
 
-809
+1122
 00:42:47,277 --> 00:42:47,400
 Dan: Yeah.
 
-810
+1123
 00:42:47,500 --> 00:42:48,300
 Kirk: Like, how [inaudible] --
 
-809
+1124
 00:42:48,027 --> 00:42:50,300
 Dan: It's mostly the ramp that
 was a problem. I feel like
 
-810
+1125
 00:42:50,300 --> 00:42:50,597
 for --
 
-811
+1126
 00:42:50,500 --> 00:42:50,700
 Bekah: Well-
 
-812
+1127
 00:42:51,000 --> 00:42:51,500
 Dan: The slide riding-
 
-813
+1128
 00:42:51,300 --> 00:42:54,000
 Bekah: -that was- that was my
 second slide riding accident.
 
-814
+1129
 00:42:51,500 --> 00:42:54,000
 Dan: -is easiest thing. You just
 put [inaudible]. Alright, Kirk.
 
-811
+1130
 00:42:54,000 --> 00:42:56,800
 You totally right though. You
 just like sit on the sled and
 
-812
+1131
 00:42:56,800 --> 00:42:57,000
 then-
 
-813
+1132
 00:42:57,000 --> 00:42:58,000
 Kirk: Let the [inaudible], you
 know?
 
-814
+1133
 00:42:57,300 --> 00:42:59,000
 Dan: -let go out the hill. Yeah.
 
-812
+1134
 00:42:59,097 --> 00:43:59,700
 Bekah: No! Sometimes, like, you
 wreck into things on sleds-
 
-813
-00:43:59,700 --> 00:43:01,700
+1135
+00:43:59,700 --> 00:43:59,701
 Dan: So, I feel like the-
 
-814
+1136
 00:43:02,000 --> 00:43:02,500
 Bekah: -and bikes.
 
-815
+1137
 00:43:02,100 --> 00:43:05,000
 Dan: -important part about sled
 riding is picking your spot.
 
-814
+1138
 00:43:06,387 --> 00:43:09,356
 Cuz if you go where there's like
 huge ramps or like — I don't
 
-815
+1139
 00:43:09,356 --> 00:43:11,300
 know where else you crashed —
 but like, trees and stuff, you
 
-816
+1140
 00:43:11,300 --> 00:43:11,500
 know-
 
-816
+1141
 00:43:11,500 --> 00:43:12,500
 Bekah: Trees. It was a tree.
 
-817
+1142
 00:43:12,000 --> 00:43:12,700
 Dan: -probably not a good idea.
 
-818
+1143
 00:43:12,700 --> 00:43:13,700
 Bekah: I hit a tree a couple of
 times [chuckles].
 
-816
+1144
 00:43:13,700 --> 00:43:15,700
 Dan: Yeah, yeah. Well, slides
 are hard to stee- like, they
 
-817
+1145
 00:43:15,700 --> 00:43:16,137
 don't-
 
-818
+1146
 00:43:16,137 --> 00:43:16,300
 Bekah: Yeah.
 
-819
+1147
 00:43:16,300 --> 00:43:18,300
 Dan: -they don't s- they don't
 -- they're not gonna, like, do
 
-818
+1148
 00:43:18,300 --> 00:43:20,000
 a sharp turn steer, you know?
 
-819
+1149
 00:43:20,217 --> 00:43:22,500
 Bekah: I remastered my fear
 though. My brother moved-
 
-820
+1150
 00:43:22,500 --> 00:43:22,800
 Dan: Sled is fun.
 
-820
+1151
 00:43:22,600 --> 00:43:25,000
 Bekah: -down the street and has
 a great sled riding hill. And I
 
-821
+1152
 00:43:25,000 --> 00:43:27,867
 have gone down that hill
 multiple times.
 
-822
+1153
 00:43:28,047 --> 00:43:31,000
 Dan: Yeah. You- you see? You can
 affect like s- like slow gradual
 
-824
+1154
 00:43:31,000 --> 00:43:34,300
 turns on sleds. You know what I
 mean? But like --
 
-825
+1155
 00:43:33,500 --> 00:43:35,000
 Bekah: I just [inaudible]
 straight down.
 
-826
+1156
 00:43:35,500 --> 00:43:38,300
 Dan: What -- I mean, I'm saying,
 you can turn slowly while-
 
-826
+1157
 00:43:38,300 --> 00:43:38,500
 Bekah: Yeah.
 
-827
+1158
 00:43:38,500 --> 00:43:39,700
 Dan: you're going fast, straight
 down.
 
-828
+1159
 00:43:40,000 --> 00:43:41,500
 Bekah: I was [inaudible] in the
 ground.
 
-826
+1160
 00:43:40,500 --> 00:43:42,000
 Dan: But you have to plan it
 ahead [laughs]. You have to plan
 
-827
+1161
 00:43:42,000 --> 00:43:44,700
 it ahead or just ditch it, is
 what I would -- what I do when I
 
-829
+1162
 00:43:44,700 --> 00:43:45,237
 wanna control.
 
-830
+1163
 00:43:44,500 --> 00:43:45,300
 Bekah: Not gonna say [??].
 
-831
+1164
 00:43:45,500 --> 00:43:45,700
 Dan: Yeah.
 
-832
+1165
 00:43:45,700 --> 00:43:46,500
 Kirk: Now in the chat --
 
-833
+1166
 00:43:45,800 --> 00:43:48,500
 Bekah: Jeff is correct. He says
 I lift heavy things and I put
 
-834
+1167
 00:43:48,500 --> 00:43:49,000
 them down.
 
-831
+1168
 00:43:49,137 --> 00:43:50,242
 Dan: Yeah. Somebody said we
 should do a challenge, a bike
 
-832
+1169
 00:43:50,242 --> 00:43:52,500
 ride challenge. But it [Bekah
 laughs] would be [inaudible]
 
-833
+1170
 00:43:52,500 --> 00:43:53,000
 I can actually-
 
-834
+1171
 00:43:53,000 --> 00:43:53,700
 Kirk: Well, [inaudible] --
 
-835
+1172
 00:43:53,700 --> 00:43:57,000
 Dan: -I can sit- sit on a bike,
 and not move, and not fall over.
 
-835
+1173
 00:43:57,000 --> 00:44:00,086
 Bekah: Dan has a nickname for
 his bike riding.
 
-836
+1174
 00:44:00,700 --> 00:44:01,000
 Dan: Yeah.
 
-837
+1175
 00:44:01,500 --> 00:44:02,000
 Bekah: Yeah [Bekah and Dan
 chuckle].
 
-836
+1176
 00:44:01,617 --> 00:44:05,500
 Dan: Yeah. It's Hotshot. Yeah,
 somebody named -- I got-
 
-837
+1177
 00:44:05,500 --> 00:44:07,000
 Kirk: [Inaudible].
 
-837
+1178
 00:44:05,700 --> 00:44:09,000
 Dan: -a nickname in- in high
 school. It- it originally from
 
-838
+1179
 00:44:09,000 --> 00:44:12,926
 bike riding, but ... that was
 [Bekah and Dan chuckle] I don't
 
-839
+1180
 00:44:12,927 --> 00:44:13,500
 know what all that stuff was,
 but --
 
-840
+1181
 00:44:13,500 --> 00:44:14,500
 Bekah: Oh. Poop emojis?
 
-841
+1182
 00:44:14,700 --> 00:44:18,700
 Dan: Oh, nice. Yeah. Bekah's-
 Bekah's daughters sent me a poop
 
-840
+1183
 00:44:18,700 --> 00:44:23,291
 emoji drawings because every
 time they come on the thing, and
 
-841
+1184
 00:44:23,291 --> 00:44:25,500
 they always want, you know,
 whatever they're waving and
 
-842
+1185
 00:44:25,500 --> 00:44:27,581
 stuff. And so I just started
 sending poop emojis and they
 
-843
+1186
 00:44:27,581 --> 00:44:29,021
 thought of [inaudible]. So --
 
-844
+1187
 00:44:29,021 --> 00:44:31,000
 Kirk: Well, I've always --
 that's been very validating to
 
-845
+1188
 00:44:31,000 --> 00:44:34,000
 me with, like, Bekah's family
 associates me with, like,
 
-846
+1189
 00:44:34,000 --> 00:44:38,000
 pancakes and hot sauce. And,
 like, Dan gets poop emojis
 
-847
+1190
 00:44:38,000 --> 00:44:39,000
 [chuckles].
 
-848
+1191
 00:44:39,500 --> 00:44:40,000
 Bekah: So I'd-
 
-849
+1192
 00:44:39,700 --> 00:44:40,300
 Dan: [Inaudible].
 
-850
+1193
 00:44:40,300 --> 00:44:41,000
 Bekah: -I don't think anybody
 knows this story.
 
-851
+1194
 00:44:41,000 --> 00:44:41,700
 Dan: I'm alright with that.
 
-849
+1195
 00:44:41,700 --> 00:44:44,000
 Bekah: The one morning, a couple
 of weeks ago, we were making
 
-850
+1196
 00:44:44,000 --> 00:44:47,000
 pancakes and my daughters
 decided they were gonna make
 
-851
+1197
 00:44:47,000 --> 00:44:52,500
 pan-Kirks [chuckles], some
 pancakes that looked like Kirk.
 
-852
+1198
 00:44:52,500 --> 00:44:54,700
 And then they argued over who
 would eat the pan-Kirk. But
 
-853
+1199
 00:44:54,700 --> 00:44:58,000
 then, it -- we only had a little
 bit of butter left. So there was
 
-854
+1200
 00:44:58,000 --> 00:45:02,300
 only one pan-Kirk and it looked
 like a tiny baby. So, I think
 
-855
+1201
 00:45:02,300 --> 00:45:06,300
 Gemma ate baby pan-Kirk
 [laughs]. Kirk is like this very
 
-856
+1202
 00:45:06,300 --> 00:45:08,202
 strange [laughs] --
 
-857
+1203
 00:45:08,202 --> 00:45:10,000
 Kirk: She sent me this, like,
 "Look! They made, like,
 
-858
+1204
 00:45:10,000 --> 00:45:13,700
 pan-Kirks." There's nothing
 special about the pancakes
 
-859
+1205
 00:45:13,700 --> 00:45:17,000
 itself [Bekah laughs]. It's just
 a small pancake. There's no
 
-859
+1206
 00:45:17,000 --> 00:45:20,700
 distinguishing. There's no,
 like, chocolate chip face.
 
-860
+1207
 00:45:21,000 --> 00:45:22,700
 It's just a pancake.
 
-860
+1208
 00:45:22,811 --> 00:45:24,702
 Bekah: We did our best with what
 we had, okay [laughs]?
 
-861
+1209
 00:45:26,000 --> 00:45:27,000
 Dan: Oh, man.
 
-861
+1210
 00:45:28,302 --> 00:45:30,000
 Kirk: Well, your best is bad.
 Don't tell them. I was very
 
-862
+1211
 00:45:30,000 --> 00:45:33,222
 [chuckles] -- it's very
 heartwarming, but also quite
 
-862
+1212
 00:45:33,222 --> 00:45:36,492
-strange. I only know how to
-make pancakes from scratch, not
+strange. I only know how to make
+pancakes from scratch, not
 
-863
+1213
 00:45:36,492 --> 00:45:39,851
 the mix. And the, like,
 proportions I learned it at are
 
-864
+1214
 00:45:39,851 --> 00:45:42,641
 the only way I can do it. So I
 can only make like enough
 
-865
+1215
 00:45:42,641 --> 00:45:46,500
 pancakes, like, a full family.
 But my family quickly-
 
-866
+1216
 00:45:46,500 --> 00:45:47,000
 Dan: [Inaudible].
 
-866
+1217
 00:45:46,600 --> 00:45:49,700
 Kirk: -like, [inaudible] they
 don't want pancakes. So I would
 
-867
+1218
 00:45:49,700 --> 00:45:53,052
 just eat, like, two pounds of
 pancakes myself. Cuz I know --
 
-869
+1219
 00:45:53,052 --> 00:45:54,000
 Bekah: You can freeze them-
 
-870
+1220
 00:45:54,000 --> 00:45:55,000
 Dan: Yeah. You- you --
 
-871
+1221
 00:45:55,000 --> 00:45:56,000
 Bekah: -and then pop them in the
 toaster.
 
-870
+1222
 00:45:56,300 --> 00:45:58,032
 Dan: Yep. It's true. They're
 good that way.
 
-871
+1223
 00:45:58,961 --> 00:46:00,700
 Kirk: Or I could eat two pounds
 of pancakes.
 
-872
+1224
 00:46:00,700 --> 00:46:01,211
 Dan: Right.
 
-873
+1225
 00:46:01,211 --> 00:46:03,000
 Bekah: Yeah. That's [inaudible]
 [laughs].
 
-874
+1226
 00:46:01,300 --> 00:46:02,700
 Dan: So you're not [inaudible].
 You're just bragging at this
 
-873
+1227
 00:46:02,700 --> 00:46:05,442
 point, is you get to eat two
 pounds of pancakes.
 
-874
+1228
 00:46:05,442 --> 00:46:08,202
 Kirk: And then I go up to them
 like, "You made me do this."
 
-875
+1229
 00:46:08,202 --> 00:46:11,700
 [Dan laughs] That's the spirit.
 
-875
+1230
 00:46:11,981 --> 00:46:16,331
 Dan: I -- so we were talking --
 I mean, we wanted to hang out in
 
-876
+1231
 00:46:16,331 --> 00:46:18,552
 the stream or whatever, and just
 hang out with people. We talked
 
-877
+1232
 00:46:18,552 --> 00:46:21,311
 about doing a podcast. Like,
 making this like a live podcast
 
-878
+1233
 00:46:21,311 --> 00:46:26,442
 episode. I realized that we
 didn't do a random question or
 
-879
+1234
 00:46:26,442 --> 00:46:28,500
 anything like that. So I was-
 
-880
-00:46:28,500 --. 00:46:28,700
+1235
+00:46:28,500 --> 00:46:28,700
 Kirk: Wait --
 
-881
+1236
 00:46:29,000 --> 00:46:30,700
 Dan: -just -- I don't have a
 plan for this. I was thinking if
 
-880
+1237
 00:46:30,700 --> 00:46:33,040
 I had [chuckles] somebody has a
 -- has- has a good, you know,
 
-882
+1238
 00:46:33,041 --> 00:46:35,862
 random question -- or Kirk, if
 you --
 
-883
+1239
 00:46:35,862 --> 00:46:36,500
 Kirk: Well, in VC today-
 
-884
+1240
 00:46:36,500 --> 00:46:38,700
 Dan: Or- or a riddle, really,
 [inaudible] Bekah.
 
-885
+1241
 00:46:37,000 --> 00:46:42,700
 Kirk: -[inaudible] sort of like
 fake icebreaker was which part
 
-884
+1242
 00:46:42,700 --> 00:46:43,210
 of -- not
 
-885
+1243
 00:46:43,211 --> 00:46:46,092
 which part of your body hurts.
 Cuz the answer can be multiple.
 
-886
+1244
 00:46:46,331 --> 00:46:49,500
 Well, like, which is the one
 you've noticed hurting, like,
 
-887
+1245
 00:46:49,500 --> 00:46:53,500
 most, recently [chuckles]. Cuz
 somehow we just all started
 
-888
+1246
 00:46:53,500 --> 00:46:56,000
 talking about the parts of our
 body with, like, creaks.
 
-889
+1247
 00:46:56,300 --> 00:47:00,000
 Bekah: My traps [chuckles]. My
 traps hurt [chuckles].
 
-890
+1248
 00:47:00,000 --> 00:47:01,376
 Dan: Which ones are your traps?
 
-891
+1249
 00:47:02,000 --> 00:47:03,000
 Bekah: Here, back here.
 
-892
+1250
 00:47:03,300 --> 00:47:04,000
 Dan: Oh, okay.
 
-893
+1251
 00:47:05,000 --> 00:47:09,700
 Bekah: I have built up too much
 muscle, and now it's very tight.
 
-894
+1252
 00:47:09,700 --> 00:47:10,500
 Dan: I have that problems too.
 
-892
+1253
 00:47:10,257 --> 00:47:11,700
 Bekah: And it hurts every day
 [laughs].
 
-893
+1254
 00:47:11,700 --> 00:47:12,500
 Kirk: You have that problem too,
 right, Dan? You just way too
 
-894
+1255
 00:47:12,500 --> 00:47:14,817
 much muscle.
 
-893
+1256
 00:47:14,817 --> 00:47:17,700
 Dan: I didn't do many trapezoid
 exercises. So --
 
-894
+1257
 00:47:18,000 --> 00:47:20,000
 Kirk: Yeah. When I was a kid in
 school-
 
-895
+1258
 00:47:20,000 --> 00:47:20,500
 Dan: I just --
 
-895
+1259
 00:47:20,300 --> 00:47:22,500
 Kirk: -I did all the triangle
 workouts. I saw [inaudible] --
 
-896
+1260
 00:47:22,300 --> 00:47:24,167
 Dan: You know, I get in the gym
 and I think tri- geometry I'm
 
-897
+1261
 00:47:24,167 --> 00:47:26,000
 like, "Yo, those trapezoids --"
 
-898
+1262
 00:47:26,500 --> 00:47:26,700
 Kirk: Boom.
 
-899
+1263
 00:47:27,000 --> 00:47:28,500
 Bekah: What about your- what
 about your [inaudible]
 
-900
+1264
 00:47:28,500 --> 00:47:29,000
 trapezoids [chuckles]?
 
-898
+1265
 00:47:25,617 --> 00:47:31,000
 Dan: [Inaudible] trapezoids
 [inaudible].
 
-899
+1266
 00:47:31,000 --> 00:47:32,700
 Kirk: [Inaudible].
 
-900
+1267
 00:47:32,700 --> 00:47:35,300
 Dan: And you gotta get the- the
 whole, the acute-
 
-901
+1268
 00:47:35,300 --> 00:47:35,700
 Bekah: Quadercept squad.
 
-899
+1269
 00:47:35,336 --> 00:47:37,601
 Dan: -and the obtuse -- the
 acute and the obtuse triangles.
 
-900
+1270
 00:47:37,601 --> 00:47:41,500
 And then make sure you hit the
 -- oh, sh-
 
-901
+1271
 00:47:41,500 --> 00:47:42,500
 Bekah: Squares [laughs].
 
-902
+1272
 00:47:42,500 --> 00:47:44,000
 Dan: Is it -- no. What's the-
 what's the per- is perfect
 
-902
+1273
 00:47:44,000 --> 00:47:47,036
-triangle -- well, no. What's
-the ... equal lateral. E-equal
+triangle -- well, no. What's the
+... equal lateral. E-equal
 
-903
+1274
 00:47:47,036 --> 00:47:50,000
 lateral- equal lateral triangle
 as well. Make sure you hit all
 
-905
+1275
 00:47:50,000 --> 00:47:51,500
 three of those. If you wanna do-
 
-906
+1276
 00:47:51,500 --> 00:47:51,700
 Kirk: Yeah.
 
-907
+1277
 00:47:51,600 --> 00:47:53,700
 Dan: -a full workout, then you
 get into the 3D and you get some
 
-906
-00:47:53,700 --> 00:47:57,700 
+1278
+00:47:53,700 --> 00:47:57,700
 cubes. And, you know, you get
 some ... other hydron things --
 
-908
+1279
 00:47:57,700 --> 00:47:59,000
 oh, man. This is where I
 [inaudible].
 
-909
+1280
 00:47:59,000 --> 00:48:00,000
 Kirk: This man is clearly --
 
-910
+1281
 00:48:00,000 --> 00:48:02,907
 Dan: I almost said it [laughs].
 
-909
+1282
 00:48:02,907 --> 00:48:06,387
 Kirk: And sports is what we're
 saying. I think someone in the
 
-910
+1283
 00:48:06,387 --> 00:48:10,286
 Slack was like, "Who could lift
 more weight?" Like, "Who could,
 
-911
+1284
 00:48:10,286 --> 00:48:12,717
 like, deadlift more?" I'm like,
 "It's- it's definitely Bekah."
 
-912
+1285
 00:48:12,746 --> 00:48:15,500
 Dan: A deadlift- a deadlift --
 Bekah would very easily -- I
 
-913
+1286
 00:48:15,500 --> 00:48:18,000
 mean, most of these probably she
 would anyway, but like a- a
 
-914
+1287
 00:48:18,000 --> 00:48:20,700
 deadlift, any of the ones where
 you need a form -- we need form
 
-915
+1288
 00:48:20,700 --> 00:48:21,327
 and stuff, like-
 
-916
+1289
 00:48:21,327 --> 00:48:22,300
 Kirk: That's all of them.
 
-917
+1290
 00:48:22,300 --> 00:48:24,416
 Dan: -the proper form -- I'm
 saying, I would just kill
 
-916
+1291
 00:48:24,416 --> 00:48:26,051
 myself. Like, I would like -- my
 back would throw [inaudible] or
 
-917
+1292
 00:48:26,051 --> 00:48:30,000
 something. You know what I mean?
 I have [inaudible] literally
 
-918
+1293
 00:48:30,000 --> 00:48:33,500
 never works out. Like, I'm
 fairly strong, but Bekah works
 
-919
+1294
 00:48:33,500 --> 00:48:37,700
 out all the time and it is very
 strong. I feel like a- I feel
 
-921
+1295
 00:48:37,700 --> 00:48:39,000
 like a bench press is where I-
 
-922
+1296
 00:48:39,000 --> 00:48:39,300
 Bekah: Yeah.
 
-922
+1297
 00:48:37,853 --> 00:48:41,700
 Dan: -like, I feel like a bench
 press, I probably could equal
 
-923
+1298
 00:48:41,700 --> 00:48:42,000
 her.
 
-924
+1299
 00:48:42,000 --> 00:48:42,300
 Kirk: Okay.
 
-925
+1300
 00:48:42,300 --> 00:48:43,000
 Dan: I dunno- I don't-
 
-926
+1301
 00:48:42,700 --> 00:48:44,700
 Bekah: Oh, you for sure could
 ... kill me.
 
-924
+1302
 00:48:43,101 --> 00:48:46,371
 Dan: -think you were -- but like
 -- be- because with bench press,
 
-925
+1303
 00:48:46,371 --> 00:48:48,000
 I don't have to worry about
 hurting myself very badly
 
-926
+1304
 00:48:48,000 --> 00:48:49,000
 [chuckles] cuz my back is
 supported.
 
-927
+1305
 00:48:48,500 --> 00:48:49,500
 Kirk: You could just sit. I
 mean, I've seen --
 
-926
+1306
 00:48:49,641 --> 00:48:51,700
 Dan: You know what I mean?
 [Laughs] Then it's just like --
 
-927
+1307
 00:48:51,700 --> 00:48:55,500
 and then it's ... you know? But
 like, any of the ones that like
 
-927
+1308
 00:48:55,500 --> 00:48:58,300
 requires skill? I mean, she's-
 
-928
+1309
 00:48:58,461 --> 00:49:00,000
 Bekah: Jesse and I talked about
 it last night.
 
-929
+1310
 00:49:00,000 --> 00:49:00,700
 Dan: -she's killing it.
 [Inaudible].
 
-929
+1311
 00:49:00,500 --> 00:49:02,481
 Bekah: I was like, "I think Dan
 could crush me in bench
 
-930
+1312
 00:49:02,481 --> 00:49:03,000
 pressing."
 
-930
+1313
 00:49:02,911 --> 00:49:04,000
 Dan: I'm- I'm I'm sup- I'm like-
 
-931
+1314
 00:49:04,000 --> 00:49:04,700
 Bekah: He was on board for that.
 
-932
+1315
 00:49:04,300 --> 00:49:06,500
 Dan: -supposedly strong for
 somebody who doesn't ever work
 
-933
+1316
 00:49:06,500 --> 00:49:06,700
 out.
 
-931
+1317
 00:49:06,700 --> 00:49:09,700
 Kirk: What I wanna know is who
 wins in cycling. I think you
 
-932
+1318
 00:49:09,700 --> 00:49:10,882
 could have an edge there.
 
-933
+1319
 00:49:11,722 --> 00:49:12,300
 Bekah: Oh, for sure.
 
-934
+1320
 00:49:12,300 --> 00:49:12,500
 Dan: Cycling?
 
-935
+1321
 00:49:12,500 --> 00:49:14,700
 Bekah: I- I don't know how to
 cycle [laughs].
 
-934
+1322
 00:49:14,700 --> 00:49:16,500
 Kirk: After, you know?
 
-935
+1323
 00:49:17,000 --> 00:49:18,500
 Bekah: Stationary bicycle?
 
-936
+1324
 00:49:19,000 --> 00:49:22,311
 Kirk: After, like, elbow scar
 McGee over there. You got a
 
-935
+1325
 00:49:22,311 --> 00:49:22,641
 chance.
 
-936
+1326
 00:49:22,500 --> 00:49:24,500
 Dan: Although, if we're going to
 have it -- so, somebody
 
-937
+1327
 00:49:24,500 --> 00:49:26,500
 mentioned triathlons. And
 there's like triathlon teams
 
-938
+1328
 00:49:26,500 --> 00:49:28,300
 too. So every -- most
 triathlons-
 
-939
-00:49:28,300 -->00:49:28,500
+1329
+00:49:28,300 --> 00:49:28,500
 Bekah: Oh.
 
-938
+1330
 00:49:28,400 --> 00:49:29,700
 Dan: -they have like team for
 competition, you know, as well.
 
-939
+1331
 00:49:29,700 --> 00:49:33,700
 So, if we do a triathlon, would
 you do run or swim?
 
-939
+1332
 00:49:34,300 --> 00:49:35,000
 Bekah: Probably swim.
 
-940
+1333
 00:49:35,500 --> 00:49:37,617
 Dan: Alright. So Kirk, that
 means you're on running?
 
-941
+1334
 00:49:37,617 --> 00:49:40,000
 [Inaudible].
 
-941
+1335
 00:49:40,797 --> 00:49:45,500
 Kirk: What am I better at than
 the two of you ... jokes? Ooh.
 
-942
+1336
 00:49:45,500 --> 00:49:48,000
 Bekah: Ha-ha. Grrr.
 
-942
+1337
 00:49:49,000 --> 00:49:51,237
 Kirk: What am I better at sports
 wise?
 
-943
+1338
 00:49:51,806 --> 00:49:54,626
 Dan: No, Joe. Bekah would win at
 push-ups easily.
 
-944
+1339
 00:49:55,000 --> 00:49:55,300
 Kirk: Easy.
 
-944
+1340
 00:49:55,300 --> 00:49:58,500
 Bekah: Oh, I don't know. I -- my
 shoulder is -- Kirk is still in
 
-945
+1341
 00:49:58,500 --> 00:50:00,626
 the hundred push-ups challenge,
 right?
 
-946
+1342
 00:50:00,987 --> 00:50:03,447
 Kirk: Yeah. But I don't do,
 like, the full ones. I'm doing
 
-947
+1343
 00:50:03,447 --> 00:50:04,500
 like incline. No shame.
 
-948
+1344
 00:50:05,847 --> 00:50:08,500
 Bekah: I -- my -- I hear my
 shoulder. I have a torn
 
-949
+1345
 00:50:08,500 --> 00:50:09,000
 something.
 
-951
+1346
 00:50:09,300 --> 00:50:11,300
 Dan: You know, my thing with-
 with push-ups, honestly, that
 
-952
+1347
 00:50:11,300 --> 00:50:14,000
 bothers me, is my wrists aren't
 flexible. Therefore my wrist
 
-953
+1348
 00:50:14,000 --> 00:50:14,500
 hurt-
 
-953
+1349
 00:50:14,500 --> 00:50:14,700
 Bekah: Oh, yeah-
 
-954
+1350
 00:50:14,700 --> 00:50:15,500
 Dan: -from bending back.
 
-955
+1351
 00:50:14,800 --> 00:50:16,000
 Bekah: -you gotta work on that.
 
-954
+1352
 00:50:16,000 --> 00:50:18,000
 Dan: Yeah. Like, they don't,
 like --
 
-955
+1353
 00:50:18,000 --> 00:50:20,246
 Bekah: My right wrist, from
 using the mouse all the time,
 
-956
+1354
 00:50:20,246 --> 00:50:21,597
 is definitely tighter than my
 left one.
 
-957
+1355
 00:50:21,597 --> 00:50:24,146
 Dan: Yeah. I'm sure I could work
 on it if I want it to. But,
 
-958
+1356
 00:50:24,146 --> 00:50:24,300
 yeah.
 
-958
+1357
 00:50:24,700 --> 00:50:26,456
 Kirk: The tunnel- the tunnel I
 traveled through the most is
 
-959
+1358
 00:50:26,456 --> 00:50:30,000
 carpool [??], for sure. But,
 like, they have those things,
 
-960
+1359
 00:50:30,000 --> 00:50:32,700
 like, those things you can fold
 instead of pressing your arms
 
-961
+1360
 00:50:32,700 --> 00:50:35,936
 flat on the ground. But they
 just -- they hurt-
 
-962
+1361
 00:50:36,000 --> 00:50:36,300
 Bekah: Yeah.
 
-962
+1362
 00:50:36,300 --> 00:50:38,300
 Kirk: -just put your arm in a
 different way. So I'm like-
 
-963
+1363
 00:50:38,300 --> 00:50:38,561
 Bekah: Yeah.
 
-963
+1364
 00:50:38,561 --> 00:50:42,300
 Kirk: -this just transferred the
 pain from like doing this to
 
-965
+1365
 00:50:42,300 --> 00:50:45,500
 like straight through. So it
 doesn't help at all.
 
-966
+1366
 00:50:45,500 --> 00:50:47,000
 Dan: Yeah. Did you read Nick's
 comment?
 
-967
-00:50:46,500 -->00:50:48,000
+1367
+00:50:46,500 --> 00:50:48,000
 Bekah: Na- no.
 
-968
+1368
 00:50:48,500 --> 00:50:50,000
 Dan: Nick just says, "I saw
 someone mountain biking on a
 
-967
+1369
 00:50:50,000 --> 00:50:52,700
 unicycle in a forest outside of
 Montreal. I wave to them and
 
-968
+1370
 00:50:52,700 --> 00:50:55,000
 they fell. I laughed."
 
-969
+1371
 00:50:55,700 --> 00:50:58,000
-Bekah: [All laugh] That's like
-a joker, but true story.
+Bekah: [All laugh] That's like a
+joker, but true story.
 
-970
+1372
 00:50:57,000 --> 00:50:58,000
 Dan: Nick- Nick, that does sound
 --
 
-971
+1373
 00:50:58,500 --> 00:50:59,800
 Kirk: It's Montreal. So it's
 definitely [inaudible]
 
-972
+1374
 00:50:59,800 --> 00:51:04,000
 [all laugh]. My trip to go home
 [inaudible].
 
-973
+1375
 00:51:03,300 --> 00:51:07,000
 Dan: Oh, man. [Inaudible]. I
 just imagine them like doing a
 
-969
+1376
 00:51:07,000 --> 00:51:11,000
 jump [Bekah chuckles] on a
 unicycle, waving to Nick, and
 
-970
+1377
 00:51:11,000 --> 00:51:14,500
 then, like, seeing them veer off
 into a tree and yelling "Sacré
 
-971
+1378
 00:51:14,500 --> 00:51:16,000
 bleu," or something like that
 [laughs].
 
-972
+1379
 00:51:16,601 --> 00:51:18,500
 Kirk: It's like "The Office".
 They have to yell, "Parkour!
 
-973
+1380
 00:51:18,500 --> 00:51:19,001
 Parkour!"
 
-973
+1381
 00:51:19,001 --> 00:51:21,072
 Bekah: Oh, my gosh. My kids love
 that.
 
-974
+1382
 00:51:22,512 --> 00:51:23,500
 Kirk: Then, it'll away. No --
 
-975
+1383
 00:51:23,500 --> 00:51:24,700
 Bekah: A mountain bike unicycle?
 
-00:51:24,700 --> 00:51:25,500
+1384
+00:51:24,500 --> 00:51:25,300
 Dan: Yeah, yeah, yeah. You know
 what?
 
-00:51:25,000--> 00:51:26,001
+1385
+00:51:25,300 --> 00:51:26,000
 Bekah: I didn't even know it was
 a thing.
 
-976
+1386
 00:51:26,001 --> 00:51:28,500
 Dan: I've- I've seen those for
 sure. A-and, like, the people
 
-977
+1387
 00:51:28,500 --> 00:51:32,000
 do, like, insane things on them.
 I've- I've seen them once. Oh,
 
-978
+1388
 00:51:32,000 --> 00:51:34,500
 I- I don't think I've seen them
 in real life, but I've seen them
 
-980
+1389
 00:51:34,500 --> 00:51:38,500
 on YouTube. If you want to know
 more, let me do --
 
-981
+1390
 00:51:37,000 --> 00:51:39,700
 Kirk: I want to -- you know, on
 Spiderman, when they tell him
 
-982
+1391
 00:51:39,700 --> 00:51:42,300
 do a flip, and then he does the
 flip, and then he was like "Oh,
 
-983
+1392
 00:51:42,300 --> 00:51:42,500
 that's-
 
-984
+1393
 00:51:42,500 --> 00:51:42,700
 Dan: Yeah.
 
-983
+1394
 00:51:42,600 --> 00:51:45,000
 Kirk: -so cool." I want to be
 on, like, both ends of that. I
 
-984
+1395
 00:51:45,000 --> 00:51:48,300
 wanna be the person saying do
 the flip and then someone else
 
-985
+1396
 00:51:48,300 --> 00:51:51,700
 does the flip. And someone says
 to me, I wanna be able to do the
 
-986
+1397
 00:51:51,700 --> 00:51:53,000
 flip in that moment.
 
-987
+1398
 00:51:52,500 --> 00:51:53,500
 Dan: Yeah. Yeah, yeah.
 
-988
+1399
 00:51:54,000 --> 00:51:56,231
 Kirk: But that's never gonna
 happen. Just, backflips are
 
-989
+1400
 00:51:56,231 --> 00:51:59,172
 terrifying. What am I better at
 than the two of you? This is --
 
-990
+1401
 00:51:59,172 --> 00:51:59,831
 I gotta figure this out.
 
-991
-00:52,000 --> 00:52:03,700
+1402
+00:52:00,000 --> 00:52:03,700
 Bekah: Kindness [chuckles],
 documentation-
 
-992
+1403
 00:52:04,000 --> 00:52:04,300
 Kirk: No.
 
-993
+1404
 00:52:04,500 --> 00:52:05,000
 Bekah: -Elm-
 
-994
+1405
 00:52:05,700 --> 00:52:06,000
 Kirk: Yes.
 
-995
+1406
 00:52:06,000 --> 00:52:06,300
 Bekah: -games.
 
-996
+1407
 00:52:07,000 --> 00:52:08,000
 Kirk: Hmm.
 
-992
+1408
 00:52:08,952 --> 00:52:10,700
 Bekah: Well, I don't know if
 Dan's better than you at games
 
-993
+1409
 00:52:10,700 --> 00:52:13,692
 or not. I like games, and very
 bad at them.
 
-994
+1410
 00:52:14,000 --> 00:52:16,700
 Kirk: I only like like two
 things. But I've -- it's --
 
-995
+1411
 00:52:16,700 --> 00:52:17,000
 Bekah: Yoga.
 
-996
+1412
 00:52:18,000 --> 00:52:21,700
 Kirk: Hmm. Not anymore. That's
 --
 
-995
+1413
 00:52:21,911 --> 00:52:23,700
 Bekah: Have you seen Dan do
 yoga?
 
-996
+1414
 00:52:23,996 --> 00:52:29,000
 Kirk: I would pay money. I
 would- I would donate time and
 
-997
+1415
 00:52:29,000 --> 00:52:31,000
-money to make that happen
-[Bekah chuckles].
+money to make that happen [Bekah
+chuckles].
 
-998
+1416
 00:52:31,000 --> 00:52:32,000
 Dan: I'm --
 
-999
+1417
 00:52:32,246 --> 00:52:34,500
 Bekah: Kirk, Kirk, it is Kirk
 Day. You are allowed to ask him
 
-1001
+1418
 00:52:34,500 --> 00:52:35,700
 to do whatever you want-
 
-1002
+1419
 00:52:35,700 --> 00:52:37,500
 Dan: Listen, I'm not doing any
 [inaudible] right now.
 
-1003
+1420
 00:52:35,800 --> 00:52:38,000
 Bekah: -right now, okay? No,
 we're not [??].
 
-1004
+1421
 00:52:37,500 --> 00:52:40,000
 Kirk: Not like the day of my
 daughter's weddings [??]
 
-1005
+1422
 00:52:40,000 --> 00:52:41,000
 [laughs]. Thank god.
 
-1002
+1423
 00:52:41,500 --> 00:52:45,000
 Dan: [Inaudible]. I don't know.
 The -- I just -- I'm not very
 
-1003
+1424
 00:52:45,000 --> 00:52:47,757
 flexible at all that. I'm --
 it's- it's a known fact.
 
-1004
+1425
 00:52:47,757 --> 00:52:49,000
 Bekah: Haikus, Kirk.
 
-1005
+1426
 00:52:49,000 --> 00:52:50,000
 Kirk: Oh, yeah.
 
-1006
+1427
 00:52:50,500 --> 00:52:53,000
 Bekah: Poetry. Maybe. I don't
 know.
 
-1005
+1428
 00:52:53,396 --> 00:52:55,500
 Kirk: Well, you -- you're-
 you're a poet. You poet. You
 
-1006
+1429
 00:52:55,500 --> 00:52:55,700
 poem.
 
-1006
+1430
 00:52:56,000 --> 00:52:57,500
 Bekah: Yeah. For sure, yeah
 [laughs].
 
-1007
+1431
 00:52:57,500 --> 00:52:58,700
 Dan: We all have dabbled in the
 poetry.
 
-1008
+1432
 00:52:59,000 --> 00:53:02,000
 Bekah: We've dab- we have all
 three dabbled in the poetry.
 
-1009
+1433
 00:53:02,000 --> 00:53:02,300
 Dan: I have --
 
-1110
+1434
 00:53:02,300 --> 00:53:02,500
 Kirk: One day --
 
-1007
+1435
 00:53:02,697 --> 00:53:05,500
 Bekah: You may be able to find
 all three of our poetry online,
 
-1008
+1436
 00:53:05,500 --> 00:53:08,300
-if you search hard enough
-[Bekah and Dan laugh].
+if you search hard enough [Bekah
+and Dan laugh].
 
-1009
+1437
 00:53:08,666 --> 00:53:11,300
 Kirk: I used to have a website.
 The first website I ever made
 
-1010
+1438
 00:53:11,300 --> 00:53:11,456
 was
 
-1011
+1439
 00:53:11,456 --> 00:53:16,121
 a WordPress site. It was called
 Shiver Sharks. Cuz that's a
 
-1012
+1440
 00:53:16,121 --> 00:53:18,700
 collective noun for sharks, and
 I found out. Cuz everyone else
 
-1013
+1441
 00:53:18,700 --> 00:53:21,882
-does like a poet of owls or
-like one on ones everyone
+does like a poet of owls or like
+one on ones everyone
 
-1014
+1442
 00:53:21,882 --> 00:53:23,700
 knows. So, I'm like, "Give me a
 weird ones like a shiver or
 
-1015
+1443
 00:53:23,700 --> 00:53:26,700
 something like that." Great. And
 then I met the -- I saw someone
 
-1015
+1444
 00:53:26,700 --> 00:53:32,500
 who had the murder of crows, and
 I was like, "Boring." I really
 
-1016
+1445
 00:53:32,500 --> 00:53:37,700
 judged them about that. But my
 website's gone. So [all laugh].
 
-1017
+1446
 00:53:37,700 --> 00:53:39,700
 I don't know what happened to
 it. WordPress was just like,
 
-1017
+1447
 00:53:39,700 --> 00:53:43,000
 "You don't do enough."
 [Inaudible].
 
-1019
+1448
 00:53:44,700 --> 00:53:45,000
 Dan: Hm.
 
-1020
+1449
 00:53:45,300 --> 00:53:45,700
 Bekah: Oh, no.
 
-1018
+1450
 00:53:46,000 --> 00:53:49,000
 Kirk: And I think I saved- I
 think I saved everything from it
 
-1019
+1451
 00:53:49,000 --> 00:53:58,000
 as a RTF Rich Text. I'm like,
 "This is great." Lost that file.
 
-1020
+1452
 00:53:58,000 --> 00:54:04,700
 Worthless. Unhelpful. This was
 before I knew about markdown or
 
-1021
+1453
 00:54:04,700 --> 00:54:06,000
 anything, really.
 
-1023
+1454
 00:54:07,722 --> 00:54:08,112
 Bekah: Yeah.
 
-1024
+1455
 00:54:08,112 --> 00:54:09,000
 Dan: Yeah.
 
-1025
+1456
 00:54:09,000 --> 00:54:10,000
 Bekah: Same.
 
-1024
+1457
 00:54:10,646 --> 00:54:13,827
 Kirk: Does anyone remember that
 thing we used to use to make
 
-1025
+1458
 00:54:13,827 --> 00:54:19,376
 websites? Ah. My professor in
 university used it. Eclipse --
 
-1026
+1459
 00:54:19,436 --> 00:54:20,000
 no.
 
-1027
+1460
 00:54:20,000 --> 00:54:20,817
 Dan: Dreamweaver?
 
-1028
+1461
 00:54:21,000 --> 00:54:21,700
 Bekah: I love Dreamweaver.
 
-1029
+1462
 00:54:21,300 --> 00:54:23,000
 Kirk: Dreamweaver!
 
-1027
+1463
 00:54:23,967 --> 00:54:26,000
 Bekah: That was the first time I
 ever code, it was in
 
-1028
+1464
 00:54:26,000 --> 00:54:26,456
 Dreamweaver.
 
-1028
+1465
 00:54:26,487 --> 00:54:26,666
 Dan: Yeah.
 
-1029
+1466
 00:54:27,000 --> 00:54:27,300
 Kirk: Yes.
 
-1029
+1467
 00:54:27,700 --> 00:54:30,000
 Dan: Yeah. I spent years in
 Dreamweaver, for sure.
 
-1030
+1468
 00:54:30,000 --> 00:54:31,500
 Kirk: It was --
 
-1030
+1469
 00:54:31,947 --> 00:54:34,000
 Bekah: I wanna do yoga with the
 goat too.
 
-1031
+1470
 00:54:34,000 --> 00:54:34,500
 Kirk: What?
 
-1031
+1471
 00:54:34,500 --> 00:54:38,500
 Bekah: Vir- Virtual Coffee
 retreat at Glenn's house.
 
-1033
+1472
 00:54:38,500 --> 00:54:42,447
 Kirk: I've seen the goat yoga
 videos. And as somebody who,
 
-1034
+1473
 00:54:42,447 --> 00:54:45,500
 like -- I see goats every day.
 Goats poop.
 
-1035
+1474
 00:54:45,500 --> 00:54:46,257
 Dan: That's a real thing.
 
-1036
+1475
 00:54:46,700 --> 00:54:47,000
 Bekah: Yeah.
 
-1037
+1476
 00:54:48,000 --> 00:54:49,300
 Kirk: Goats poop.
 
-1038
+1477
 00:54:49,700 --> 00:54:52,500
 Dan: Is the goat doing yoga too
 or is the goat just like --
 
-1037
+1478
 00:54:52,500 --> 00:54:56,000
 Kirk: You do the yoga, and a
 bunch of little like kid goats,
 
-1038
+1479
 00:54:56,000 --> 00:54:58,700
 just kind of, like, amble about,
 and sometimes they just climb
 
-1039
+1480
 00:54:58,700 --> 00:55:00,717
 you cuz that's their thing.
 
-1040
+1481
 00:55:00,717 --> 00:55:01,286
 Dan: Oh, sure. I mean that --
 yeah.
 
-1041
+1482
 00:55:01,556 --> 00:55:03,700
 Bekah: Can we do it with
 fainting goats too? And then we
 
-1042
+1483
 00:55:03,700 --> 00:55:05,500
 could, like, jump up and scare
 'em?
 
-1043
+1484
 00:55:06,000 --> 00:55:06,500
 Dan: Fireworks.
 
-1044
+1485
 00:55:06,300 --> 00:55:07,300
 Kirk: You're mean to the goats.
 
-1044
+1486
 00:55:08,396 --> 00:55:10,500
 Dan: Yeah, Nick, I use
 Fireworks. Yeah, Dreamewea- so
 
-1045
+1487
 00:55:10,500 --> 00:55:12,000
 that's the Macromedia suite,
 like-
 
-1046
+1488
 00:55:12,000 --> 00:55:12,700
 Bekah: Oh, yeah.
 
-1047
+1489
 00:55:13,000 --> 00:55:14,700
 Dan: -Dreamweaver, Fireworks,
 and then like Flash, if you do a
 
-1046
+1490
 00:55:14,700 --> 00:55:19,000
 Flash. And ... there was another
 one that I didn't use very much,
 
-1047
+1491
 00:55:19,000 --> 00:55:22,500
 like a more of designing one.
 But ... yeah. I was in
 
-1049
+1492
 00:55:22,500 --> 00:55:24,500
 Dreamweavers, Fireworks -- and,
 like, Dreamweaver was actually
 
-1051
+1493
 00:55:24,500 --> 00:55:29,000
 really good. Even not using the,
 like, generated stuff, but it
 
-1053
+1494
 00:55:29,000 --> 00:55:30,500
 was a good, like, code editor.
 Like, I used it-
 
-1054
+1495
 00:55:30,500 --> 00:55:30,700
 Bekah: Yeah.
 
-1055
+1496
 00:55:31,000 --> 00:55:34,856
 Dan: -as my, like, just code
 editor for -- I dunno. I dunno
 
-1056
+1497
 00:55:34,887 --> 00:55:35,500
 when I stopped. But like a long
 time. [Inaudible].
 
-1057
+1498
 00:55:35,700 --> 00:55:39,327
 Bekah: Well, my first job out of
 -- my first full-time job out
 
-1059
+1499
 00:55:39,327 --> 00:55:41,786
 of college, I was a community
 organizer for an environmental
 
-1060
+1500
 00:55:41,786 --> 00:55:44,000
 non-profit. And the executive
 director-
 
-1061
+1501
 00:55:44,000 --> 00:55:44,700
 Kirk: [Inaudible] tracks [??].
 
-1062
+1502
 00:55:45,000 --> 00:55:46,887
 Bekah: -my first week, he was
 
-1061
+1503
 00:55:46,887 --> 00:55:51,300
 like, "Do you know how to use --
 how -- do you know code?" Like,
 
-1063
+1504
 00:55:51,300 --> 00:55:54,700
 "No." He was like, "Okay. Go
 home this weekend and learn HTML
 
-1064
+1505
 00:55:54,700 --> 00:55:58,700
 and CSS. And I was like, "Okay."
 Like, Jesse was my boyfriend at
 
-1066
+1506
 00:55:58,700 --> 00:56:02,500
 the time. And I went home and he
 had like textbooks on HTML and
 
-1067
+1507
 00:56:02,500 --> 00:56:04,700
 CSS. So, then we went over those
 things, and like, "All right, I
 
-1068
+1508
 00:56:04,700 --> 00:56:05,967
 know it. I know it now
 [laughs]."
 
-1069
+1509
 00:56:07,300 --> 00:56:07,700
 Dan: That's awesome.
 
-1069
+1510
 00:56:08,000 --> 00:56:10,476
 Kirk: It took all weekend. I'm
 pretty much an expert.
 
-1070
+1511
 00:56:10,476 --> 00:56:12,000
 Dan: Nailed it. Yep. Yeah.
 
-1072
+1512
 00:56:13,146 --> 00:56:16,300
 Kirk: Just to say, Jeff- Jeff,
 in the chat, was like, "Do
 
-1074
+1513
 00:56:16,300 --> 00:56:19,072
 push-ups on your fists, no full
 wrist bend." Again, like, we're
 
-1075
+1514
 00:56:19,072 --> 00:56:22,000
 just trading problems here
 [Bekah chuckles].
 
-1076
+1515
 00:56:23,000 --> 00:56:29,467
 That's not- that's not better.
 Yeah. Shoutout to --
 
-1077
+1516
 00:56:29,467 --> 00:56:32,077
 that's a Dreamweaver. I remember
 like a lot of purple. It was all
 
-1078
+1517
 00:56:32,077 --> 00:56:35,257
 like purple involved for some
 reason. Oh, I have a great bad
 
-1079
+1518
 00:56:35,257 --> 00:56:38,047
 joke. I just heard it. This is
 apparently very popular, but
 
-1080
+1519
 00:56:38,077 --> 00:56:41,300
 it's the first time I heard it.
 Bekah, don't ... ruin it.
 
-1081
+1520
 00:56:41,300 --> 00:56:41,500
 Bekah: Okay.
 
-1082
+1521
 00:56:43,700 --> 00:56:44,000
 Kirk: Which --
 
-1081
+1522
 00:56:44,067 --> 00:56:44,700
 Dan: Or Kirk's gonna fire you.
 
-1082
+1523
 00:56:45,000 --> 00:56:46,500
 Kirk: I -- do-
 
-1083
+1524
 00:56:46,500 --> 00:56:47,000
 Bekah: Kirk doesn't fire me.
 
-1084
+1525
 00:56:47,000 --> 00:56:51,000
 Kirk: -all Java developers wear
 glasses?
 
-1082
+1526
 00:56:53,876 --> 00:56:55,527
 Dan: This is where you say, "I
 don't know why."
 
-1083
+1527
 00:56:56,000 --> 00:56:59,000
 Bekah: Oh. [Dan chuckles] I
 don't know why.
 
-1083
+1528
 00:56:59,000 --> 00:57:02,757
 Kirk: That was really good.
 Because they can't see sharp.
 
-1084
+1529
 00:57:04,166 --> 00:57:05,000
 Dan: Aah.
 
-1084
+1530
 00:57:05,000 --> 00:57:08,306
 Bekah: Ooh, nice. I was not
 going in that direction. I was
 
-1085
+1531
 00:57:08,306 --> 00:57:08,847
 going more with --
 
-1086
+1532
 00:57:09,117 --> 00:57:12,700
 Kirk: If- if you were a software
 developer in like 1998, that
 
-1087
+1533
 00:57:12,700 --> 00:57:16,000
 would have been incredibly
 [inaudible][chuckles]. Like,
 
-1088
+1534
 00:57:16,000 --> 00:57:17,487
 back when they were basically
 like --
 
-1088
+1535
 00:57:17,757 --> 00:57:22,000
 Dan: I never heard of C# in
 1998. This is like C++ isn't it?
 
-1089
+1536
 00:57:22,500 --> 00:57:23,967
 When did C# become a thing?
 
-1090
+1537
 00:57:24,356 --> 00:57:29,700
 Kirk: Okay. 2005. That's, again,
 you know, back when like --
 
-1091
+1538
 00:57:29,500 --> 00:57:31,996
 Bekah: Well, you're like 13. You
 didn't hear of anything.
 
-1092
+1539
 00:57:31,996 --> 00:57:34,000
 Dan: I wasn't 13. We don't need
 to talk about how old I was,
 
-1093
+1540
 00:57:34,000 --> 00:57:37,500
 but I wasn't -- I was in
 computer science in college,
 
-1094
+1541
 00:57:37,500 --> 00:57:39,286
 which was after that. And --
 
-1095
+1542
 00:57:39,286 --> 00:57:41,700
 Kirk: Nick Taylor's heard it
 though. That's all the
 
-1096
+1543
 00:57:41,700 --> 00:57:43,000
 validation I need.
 
-1097
+1544
 00:57:42,700 --> 00:57:47,000
 Dan: [Inaudible] C++. Does C++
 not exist anymore?
 
-1097
+1545
 00:57:47,186 --> 00:57:51,500
 Kirk: Yeah. People use it to
 write-
 
-1098
+1546
 00:57:51,500 --> 00:57:52,700
 Dan: What's the difference
 between that and C#?
 
-1099
+1547
 00:57:52,700 --> 00:57:55,387
 Kirk: -Unity -- whoa, whoa,
 buddy.
 
-1098
+1548
 00:57:55,387 --> 00:57:56,500
 Dan: I don't know. I'm asking.
 
-1099
+1549
 00:57:56,500 --> 00:57:57,000
 Bekah: How dare you.
 
-1100
+1550
 00:57:57,000 --> 00:57:57,500
 Kirk: I mean --
 
-1101
+1551
 00:57:57,500 --> 00:57:58,700
 Dan: I'm not- I'm not saying
 there's no difference. I'm
 
-1099
+1552
 00:57:58,700 --> 00:58:00,000
 literally asking. I don't know.
 
-1100
+1553
 00:58:00,000 --> 00:58:02,572
 Kirk: C# is all .NET, right?
 It's all Microsoft.
 
-1101
+1554
 00:58:02,572 --> 00:58:03,000
 Dan: Oh, okay.
 
-1101
+1555
 00:58:03,572 --> 00:58:07,500
 Kirk: Right? That's this -- if
 you're in Microsoft, 90% of
 
-1102
+1556
 00:58:07,500 --> 00:58:14,700
 the time you're writing C#. And
 C++ is not. C++ is still
 
-1104
+1557
 00:58:14,700 --> 00:58:21,700
 considered like the lang du jour
 for like high-performance stuff
 
-1106
+1558
 00:58:21,700 --> 00:58:26,700
 if you don't wanna get, like,
 down to C, I guess. But I feel
 
-1107
+1559
 00:58:26,700 --> 00:58:29,300
 like C++, their [??] favorite
 thing to do is like complain
 
-1108
+1560
 00:58:29,300 --> 00:58:30,700
 about C++ [chuckles].
 
-1109
+1561
 00:58:30,700 --> 00:58:31,000
 Dan: [Chuckles] Sure.
 
-1108
+1562
 00:58:31,931 --> 00:58:32,621
 Kirk: Kinda like JavaScript
 devs.
 
-1109
+1563
 00:58:32,621 --> 00:58:34,406
 Dan: Like, yeah, you -- if you
 get to a certain level, that's
 
-1110
+1564
 00:58:34,406 --> 00:58:35,351
 just gonna be --
 
-1111
+1565
 00:58:35,351 --> 00:58:37,871
 Kirk: Yeah. Like, if it's useful
 enough, like, there'll be enough
 
-1112
+1566
 00:58:37,871 --> 00:58:40,300
 code written, then there isn't
 something to complain about.
 
-1114
+1567
 00:58:40,782 --> 00:58:45,000
 Dan: Like, Emily ... tells
 people -- like, sh- she was a --
 
-1115
+1568
 00:58:45,000 --> 00:58:47,300
 on a trip with her grandma and
 she's like, "Yeah, Dan hates
 
-1116
+1569
 00:58:47,300 --> 00:58:50,300
 computers." And she knows that,
 like, I do this -- I do this
 
-1117
+1570
 00:58:50,300 --> 00:58:52,500
 for a living, you know? But it's
 true. [Laughs] I'm like -- I
 
-1118
+1571
 00:58:52,500 --> 00:58:54,700
 just -- she- she didn't
 understand -- you know, she's
 
-1119
+1572
 00:58:54,700 --> 00:58:57,500
 like, "What? What does that
 mean?" She's like, "Yeah. Dan
 
-1119
+1573
 00:58:57,500 --> 00:58:59,300
 hates computers." I'm like
 [laughs] -- cuz she told me a
 
-1120
+1574
 00:58:59,300 --> 00:59:01,700
 story -- cuz I was like -- oh,
 yesterday, I spent like three
 
-1121
+1575
 00:59:01,700 --> 00:59:05,592
 hours trying to get — I almost
 did it. I almost went over a
 
-1122
+1576
 00:59:05,592 --> 00:59:11,231
 PG-13 again — Ruby to work again
 on my computer. And it was
 
-1123
+1577
 00:59:11,231 --> 00:59:14,112
 really annoying and it, like,
 killed my whole day, you know?
 
-1124
+1578
 00:59:14,411 --> 00:59:17,500
 Anyway, I was complaining about
 it at home, and was like, "Hey,
 
-1125
+1579
 00:59:17,500 --> 00:59:19,000
 I hate computers-
 
-1126
+1580
 00:59:19,000 --> 00:59:19,500
 Kirk: The first time --
 
-1127
+1581
 00:59:19,500 --> 00:59:21,000
 Dan: -I don't like them." So ...
 you know?
 
-1126
+1582
 00:59:21,000 --> 00:59:22,961
 Kirk: Well, the first time I
 learned Ruby, it was similar to
 
-1127
+1583
 00:59:23,021 --> 00:59:27,000
 Bekah's situation. I was in a
 internship. And they were like,
 
-1128
+1584
 00:59:27,000 --> 00:59:29,500
 "Well, we can't -- any -- you
 can't get any developers to help
 
-1128
+1585
 00:59:29,500 --> 00:59:31,300
 in this project. So you guys are
 gonna do it yourself." And we
 
-1129
+1586
 00:59:31,300 --> 00:59:34,000
 were like, "Okay." "Any of you
 know Ruby?" "No."
 
-1130
+1587
 00:59:34,000 --> 00:59:37,572
 And then -- this was back in the
 time they were like, "Here's the
 
-1131
+1588
 00:59:37,572 --> 00:59:41,382
 instructions for how to install
 this on your machine. If you get
 
-1132
+1589
 00:59:41,382 --> 00:59:45,822
 it wrong, you'll probably break
 the machine. Good luck." So,
 
-1133
+1590
 00:59:45,882 --> 00:59:49,500
 that's like [chuckles] what's
 [inaudible] Ruby in, and it was
 
-1134
+1591
 00:59:49,500 --> 00:59:53,000
 super painful. And I didn't,
 like, look at a line of Ruby
 
-1134
+1592
 00:59:53,000 --> 00:59:58,092
 again for like 10 years. So ...
 you know? Onboarding matters.
 
-1136
+1593
 00:59:58,092 --> 01:00:02,700
 Dan: Yeah. No. That's -- it's
 like, it doesn't matter. Every
 
-1137
+1594
 01:00:02,700 --> 01:00:03,500
 time I have to do something
 
-1138
+1595
 01:00:03,500 --> 01:00:05,500
 with Ruby -- and I- I just do it
 so infrequently that it's, you
 
-1140
+1596
 01:00:05,500 --> 01:00:08,000
 know, that's why it's a problem
 for me, obviously. But --
 
-1142
+1597
 01:00:08,000 --> 01:00:11,681
 Kirk: To be fair, I feel like I
 do Python stuff all the time
 
-1143
+1598
 01:00:11,681 --> 01:00:15,500
 and I still mess it up, like,
 getting it to work on my
 
-1144
+1599
 01:00:15,500 --> 01:00:18,581
 machine. I'm just -- I just want
 
-1145
+1600
 01:00:18,581 --> 01:00:23,000
 things to work. I just wanna
 click work and then they work.
 
-1146
+1601
 01:00:23,500 --> 01:00:24,000
 Dan: Yep.
 
-1146
+1602
 01:00:24,000 --> 01:00:26,382
 Kirk: Specifically the
 installation and running part.
 
-1147
+1603
 01:00:26,382 --> 01:00:26,500
 Bekah: Yes.
 
-1148
+1604
 01:00:26,700 --> 01:00:27,000
 Dan: Yep.
 
-1147
+1605
 01:00:27,311 --> 01:00:28,302
 Bekah: That's the worst.
 
-1148
+1606
 01:00:30,132 --> 01:00:33,731
 Kirk: I got a tutorial, I'm
 like, "Oh, I'm gonna NPM,
 
-1149
+1607
 01:00:33,731 --> 01:00:38,981
 install, do your thing. NPM did
 its thing. Do the thing, run,
 
-1150
+1608
 01:00:39,371 --> 01:00:43,061
 didn't work. I Google the err-
 you know, it's bad when you
 
-1151
+1609
 01:00:43,061 --> 01:00:45,500
 search for an error and it takes
 you to, like, the official
 
-1152
+1610
 01:00:45,500 --> 01:00:51,000
 GitHub, like, issues unresolved
 page. Like, "Oh, no."
 
-1153
+1611
 01:00:51,000 --> 01:00:51,500
 Bekah: Damn.
 
-1154
+1612
 01:00:52,000 --> 01:00:53,000
 Kirk: I can't escape [inaudible]
 --
 
-1153
+1613
 01:00:53,000 --> 01:00:56,500
 Dan: No, I was deep into that
 yesterday. A bunch of M1s that
 
-1154
+1614
 01:00:56,500 --> 01:00:57,000
 -- doesn't matter.
 
-1155
+1615
 01:00:57,000 --> 01:00:57,300
 Bekah: Yeah.
 
-1155
+1616
 01:00:57,300 --> 01:01:00,112
 Dan: Anyway, computers are
 annoying. And I hate them.
 
-1156
+1617
 01:01:00,592 --> 01:01:03,000
 Bekah: Also, I have to go. So
 [laughs] --
 
-1157
+1618
 01:01:03,000 --> 01:01:06,652
-Dan: Ooh. You have to leave
-at 3? Not 3.30? Aah.
+Dan: Ooh. You have to leave at
+3? Not 3.30? Aah.
 
-1158
+1619
 01:01:06,652 --> 01:01:08,931
 Kirk: I thought you were hanging
 out for like a week.
 
-1159
+1620
 01:01:09,500 --> 01:01:10,000
 Dan: Oh, man.
 
-1159
+1621
 01:01:11,362 --> 01:01:12,500
 Bekah: I have children.
 
-1160
+1622
 01:01:12,500 --> 01:01:13,500
 Dan: Bekah needs to go.
 
-1161
+1623
 01:01:13,500 --> 01:01:16,500
 Bekah: I have to go clean up the
 creek in my neighbourhood.
 
-1162
-001:01:16,500 --> 01:01:18,500
+1624
+01:01:16,500 --> 01:01:18,500
 Dan: She needs to go clean up
 the creek.
 
-1163
+1625
 01:01:18,500 --> 01:01:20,000
 Kirk: Do you smokey the bear?
 
-1164
+1626
 01:01:20,472 --> 01:01:23,500
 Bekah: [Chuckles] For earth day.
 Week. Month.
 
-1165
+1627
 01:01:25,000 --> 01:01:31,000
 Dan: Kirk, I just wanna say
 happy Kirk Day to us all.
 
-1167
+1628
 01:01:31,722 --> 01:01:34,500
 Bekah: We're glad to have you as
 our one and only Kirk-
 
-1168
+1629
 01:01:33,500 --> 01:01:35,952
 Dan: Thank- thank you for
 joining us [chuckles].
 
-1168
+1630
 01:01:35,952 --> 01:01:36,641
 Bekah: -in the entire world.
 
-1169
+1631
 01:01:37,331 --> 01:01:37,700
 Kirk: I am-
 
-1170
+1632
 01:01:38,000 --> 01:01:38,500
 Dan: That too.
 
-1171
+1633
 01:01:38,500 --> 01:01:43,700
 Kirk: -I'm happy to provide me
 as a catalyst for the cool
 
-1170
+1634
 01:01:43,700 --> 01:01:48,000
 people here. Kirk Day is weird.
 But the people who like it are
 
-1171
+1635
 01:01:48,000 --> 01:01:52,452
 great [all laugh]. We're kind of
 settled on this.
 
-1172
+1636
 01:01:53,700 --> 01:01:56,300
 Dan: I'm glad you're around. We
 didn't plan any of this at all.
 
-1173
+1637
 01:01:56,300 --> 01:01:56,500
 So-
 
-1174
+1638
 01:01:56,500 --> 01:01:57,000
 Bekah: Mm-hmm.
 
-1175
+1639
 01:01:57,500 --> 01:01:58,700
 Dan: -I appreciate you, you
 know?
 
-1174
+1640
 01:01:58,992 --> 01:02:00,822
 Bekah: Dan was like, "We should
 have an agenda." And I was like
 
-1175
+1641
 01:02:00,822 --> 01:02:02,862
 --
 
-1175
+1642
 01:02:02,862 --> 01:02:04,500
 Dan: We did get a lot of stuff
 done today.
 
-1176
+1643
 01:02:04,500 --> 01:02:05,300
 Bekah: We got a ton of stuff
 done.
 
-1177
+1644
 01:02:04,800 --> 01:02:05,700
 Dan: It was a- it was a good --
 
-1176
+1645
 01:02:06,000 --> 01:02:09,282
-Bekah: But most importantly,
-we saw Kirk on Kirk Day and
+Bekah: But most importantly, we
+saw Kirk on Kirk Day and
 
-1177
+1646
 01:02:09,282 --> 01:02:10,481
 changed our profile pictures-
 
-1178
+1647
 01:02:11,000 --> 01:02:11,300
 Dan: Indeed.
 
-1179
+1648
 01:02:11,300 --> 01:02:12,000
 Bekah: -for Kirk.
 
-1178
+1649
 01:02:12,266 --> 01:02:15,500
 Kirk: Nick Taylor's profile
 picture is sideways. I don't --
 
-1179
+1650
 01:02:15,500 --> 01:02:20,000
 Bekah: [Bekah and dan laugh] We
 noticed that.
 
-1180
+1651
 01:02:20,000 --> 01:02:21,447
 Dan: That's awesome.
 
-1180
+1652
 01:02:21,447 --> 01:02:22,347
 Bekah: It all makes sense.
 
-1181
+1653
 01:02:23,047 --> 01:02:26,000
 Kirk: The Kirk has gone rogue.
 [Bekah laughs] We are a legion.
 
-1182
+1654
 01:02:26,000 --> 01:02:29,500
 Bekah: [Laughs] Oh, my gosh.
 Well, that seems like a great
 
-1183
+1655
 01:02:29,500 --> 01:02:30,927
 way to end.
 
-1183
+1656
 01:02:30,927 --> 01:02:33,000
 Dan: Yep. That's a good one.
 Thank you everybody for hanging
 
-1185
+1657
 01:02:33,000 --> 01:02:36,000
 out, and happy Kirk Day, and --
 
-1186
+1658
 01:02:36,000 --> 01:02:37,000
 Bekah: We'll see you all
 Thursday.
 
-1187
+1659
 01:02:37,000 --> 01:02:37,700
 Dan: See you Thursday.
 
-1186
+1660
 01:02:38,396 --> 01:02:41,300
 Kirk: Don't- don't do another
 one. No more Kirk Days. From
 
-1187
+1661
 01:02:41,300 --> 01:02:41,500
 Kirk.
 
-1188
+1662
 01:02:42,000 --> 01:02:43,300
 Dan: See you next year at Kirk
 Day.
 
-1189
+1663
 01:02:43,300 --> 01:02:44,000
 Bekah: We do what we want.
 
-1190
+1664
 01:02:43,500 --> 01:02:45,000
 Kirk: [Inaudible] next year. The
 end.
 
-1191
+1665
 01:02:45,300 --> 01:02:46,000
 Bekah: You gonna fire us
 [laughs]?
 
-1192
+1666
 01:02:46,700 --> 01:02:50,000
 Kirk: Yeah. I'm gonna fire every
 single one of you.
 
-1193
+1667
 01:02:50,000 --> 01:02:51,000
 Bekah: You said you wouldn't
 fire me.
 
-1187
+1668
 01:02:52,500 --> 01:02:55,000
 Kirk: Yeah. But it's collective.
 It's fine.
 
-1188
+1669
 01:02:55,700 --> 01:02:56,000
 Dan: Alright.
 
-1189
+1670
 01:02:56,300 --> 01:02:57,500
 Kirk: Okay. Bye.
 
-1188
+1671
 01:03:01,206 --> 01:03:03,000
 Dan: Thank you for listening to
 this episode of the Virtual
 
-1189
+1672
 01:03:03,000 --> 01:03:07,052
 Coffee Podcast. This episode was
 produced by Dan Ott and Bekah
 
-1190
+1673
 01:03:07,052 --> 01:03:09,500
 Hawrot Weigel. If you have
 questions or comments, you can
 
-1192
+1674
 01:03:09,500 --> 01:03:12,842
 hit us up on Twitter at
 VirtualCoffeeIO, or email us at
 
-1193
+1675
 01:03:12,842 --> 01:03:16,000
 podcast@virtualcoffee.io. You
 can find the show notes, sign up
 
-1195
-01:03:16,000 --> 01:03:18,351
+1676
+01:03:16,000 --> 01:03:17,175
 for the newsletter, check out
-any of our other resources on our
+any of our other resources on
 
-1196
+1677
+01:03:17,175 --> 01:03:18,350
+our
+
+1678
 01:03:18,351 --> 01:03:21,742
 website, virtualcoffee.io. If
 you're interested in sponsoring
 
-1197
+1679
 01:03:21,742 --> 01:03:24,141
 Virtual Coffee, you can find out
 more information on our website
 
-1198
+1680
 01:03:24,411 --> 01:03:28,851
 at virtualcoffee.io/sponsorship.
 Please subscribe to our podcast
 
-1199
+1681
 01:03:28,882 --> 01:03:31,700
 and be sure to leave us a
 review. Thanks for listening,
 
-1200
+1682
 01:03:31,700 --> 01:03:33,092
 and we'll see you next week!


### PR DESCRIPTION
## Links
Closes #45 

## Description
- Improve transcript Season 5 Special Kirk Day episode.
- Fix timestamps manually.
- Run `yarn check-srt` and fix incorrect timestamp formatting.